### PR TITLE
fix: generate into repo root, replacing scaffold

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -16,12 +16,15 @@ jobs:
           curl -sL https://raw.githubusercontent.com/hotdata-dev/www.hotdata.dev/main/api/openapi.yaml \
             -o openapi.yaml
 
+      - name: Clean existing source
+        run: rm -rf src/
+
       - name: Generate client
         run: |
           npx @openapitools/openapi-generator-cli generate \
             -i openapi.yaml \
             -g rust \
-            -o generated/ \
+            -o . \
             --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true
 
       - name: Create PR


### PR DESCRIPTION
Generate directly into repo root instead of generated/ subdirectory so the scaffold gets fully replaced.