### PR TITLE
fix: skip spec validation for OpenAPI 3.1

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -36,7 +36,8 @@ jobs:
             -i openapi.yaml \
             -g rust \
             -o . \
-            --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true
+            --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true \
+            --skip-validate-spec
 
       - name: Create PR
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
openapi-generator-cli validation doesn't fully support 3.1 constructs.