### PR TITLE
fix(ci): exclude fetched openapi.yaml from generated PR

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -41,6 +41,9 @@ jobs:
             --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true \
             --skip-validate-spec
 
+      - name: Clean up fetched spec
+        run: rm -f openapi.yaml
+
       - name: Create PR
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
Removes the fetched spec before creating the PR so it doesn't get committed.