### PR TITLE
fix(ci): add generator ignore list and custom user-agent

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -38,7 +38,7 @@ jobs:
             -i openapi.yaml \
             -g rust \
             -o . \
-            --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true \
+            --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true,userAgent=hotdata-rust/1.0.0 \
             --skip-validate-spec
 
       - name: Clean up generated artifacts

--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -1,0 +1,3 @@
+.travis.yml
+git_push.sh
+README.md


### PR DESCRIPTION
Excludes boilerplate files from generation and sets user-agent to hotdata-rust/1.0.0.