### PR TITLE
fix(ci): use --http-user-agent flag for user-agent config

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -39,7 +39,7 @@ jobs:
             -g rust \
             -o . \
             --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true \
-            --http-user-agent hotdata-rust/1.0.0 \
+            --http-user-agent hotdata-rust/0.0.0 \
             --skip-validate-spec
 
       - name: Clean up generated artifacts

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -38,7 +38,8 @@ jobs:
             -i openapi.yaml \
             -g rust \
             -o . \
-            --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true,userAgent=hotdata-rust/1.0.0 \
+            --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true \
+            --http-user-agent hotdata-rust/1.0.0 \
             --skip-validate-spec
 
       - name: Clean up generated artifacts


### PR DESCRIPTION
The Rust generator ignores the userAgent additional property. Use the --http-user-agent CLI flag instead.