### PR TITLE
fix(ci): use PACKAGE_VERSION env var for version and user-agent

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -33,16 +33,18 @@ jobs:
         run: rm -rf src/
 
       - name: Generate client
+        env:
+          PACKAGE_VERSION: "0.1.0"
         run: |
           npx @openapitools/openapi-generator-cli generate \
             -i openapi.yaml \
             -g rust \
             -o . \
-            --additional-properties=packageName=hotdata,library=reqwest,supportAsync=true \
-            --http-user-agent hotdata-rust/0.0.0 \
+            --additional-properties=packageName=hotdata,packageVersion=$PACKAGE_VERSION,library=reqwest,supportAsync=true \
+            --http-user-agent "hotdata-rust/${PACKAGE_VERSION}" \
             --skip-validate-spec
 
-      - name: Clean up generated artifacts
+      - name: Clean up fetched spec
         run: rm -f openapi.yaml
 
       - name: Verify generated client compiles


### PR DESCRIPTION
Single source of truth for package version — flows into both Cargo.toml (via packageVersion) and the user-agent header (via --http-user-agent).