### PR TITLE
fix(codegen): per-scheme apiKey via mustache template override

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -40,6 +40,7 @@ jobs:
             -i openapi.yaml \
             -g rust \
             -o . \
+            -t .openapi-generator-templates \
             --additional-properties=packageName=hotdata,packageVersion=$PACKAGE_VERSION,library=reqwest,supportAsync=true \
             --http-user-agent "hotdata-rust/${PACKAGE_VERSION}" \
             --skip-validate-spec
@@ -48,6 +49,10 @@ jobs:
         run: rm -f openapi.yaml
 
       - name: Verify generated client compiles
+        # cargo check is the drift tripwire for the template override — if
+        # openapi-generator rearranges the auth-emission mustache variables
+        # in a future version, the override will produce non-compiling code
+        # and this step fails loudly instead of shipping wrong output.
         run: cargo check
 
       - name: Create PR

--- a/.openapi-generator-templates/README.md
+++ b/.openapi-generator-templates/README.md
@@ -1,0 +1,31 @@
+# Mustache template override
+
+Fixes a limitation in openapi-generator's rust/reqwest target: the stock
+templates model `Configuration.api_key` as a single `Option<ApiKey>` and
+emit the same value for every `apiKey` security scheme on an operation.
+For the Hotdata API — which declares distinct `X-Workspace-Id`,
+`X-Sandbox-Id`, and `X-Session-Id` schemes — that means a sandbox id
+would be sent as the workspace id and vice versa.
+
+These templates replace that field with `api_keys: HashMap<String, ApiKey>`
+keyed by header name, and change the per-operation header-emission code
+to look up the right scheme: `configuration.api_keys.get("X-Workspace-Id")`.
+
+## Why live here instead of upstream
+
+Upstream PR [#19511](https://github.com/OpenAPITools/openapi-generator/pull/19511)
+lands the same fix but was closed as breaking; the maintainer wants it
+gated behind a generator flag (tracked in
+[#20069](https://github.com/OpenAPITools/openapi-generator/pull/20069))
+before merging. Until that gate work happens we ship the patch locally.
+
+## Drift tripwire
+
+The regenerate workflow runs `cargo check` on the generated client. If a
+future openapi-generator release restructures the auth-emission code such
+that our overrides produce non-compiling output, CI fails loudly rather
+than shipping subtly wrong code.
+
+The openapi-generator version is pinned in `openapitools.json`
+(currently 7.20.0). Bumping that pin should be accompanied by diffing
+these templates against upstream's `modules/openapi-generator/src/main/resources/rust/` directory.

--- a/.openapi-generator-templates/reqwest/api.mustache
+++ b/.openapi-generator-templates/reqwest/api.mustache
@@ -1,0 +1,651 @@
+{{>partial_header}}
+
+use reqwest;
+use serde::{Deserialize, Serialize, de::Error as _};
+use crate::{apis::ResponseContent, models};
+use super::{Error, configuration, ContentType};
+{{#operations}}
+{{#operation}}
+{{#vendorExtensions.useAsyncFileStream}}
+use tokio::fs::File as TokioFile;
+use tokio_util::codec::{BytesCodec, FramedRead};
+{{/vendorExtensions.useAsyncFileStream}}
+{{/operation}}
+{{/operations}}
+
+{{#operations}}
+{{#operation}}
+{{#vendorExtensions.x-group-parameters}}
+{{#allParams}}
+{{#-first}}
+/// struct for passing parameters to the method [`{{operationId}}`]
+#[derive(Clone, Debug)]
+pub struct {{{operationIdCamelCase}}}Params {
+{{/-first}}
+    {{#description}}
+    /// {{{.}}}
+    {{/description}}
+    pub {{{paramName}}}: {{!
+    ### Option Start
+    }}{{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{!
+    ### &str and Vec<&str>
+    }}{{^isUuid}}{{#isString}}{{#isArray}}Vec<{{/isArray}}String{{#isArray}}>{{/isArray}}{{/isString}}{{/isUuid}}{{!
+    ### UUIDs
+    }}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}String{{#isArray}}>{{/isArray}}{{/isUuid}}{{!
+    ### Models and primative types
+    }}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{!
+    ### Option End
+    }}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{!
+    ### Comma for next arguement
+    }}{{^-last}},{{/-last}}
+{{#-last}}
+}
+
+{{/-last}}
+{{/allParams}}
+{{/vendorExtensions.x-group-parameters}}
+{{/operation}}
+{{/operations}}
+
+{{#supportMultipleResponses}}
+{{#operations}}
+{{#operation}}
+/// struct for typed successes of method [`{{operationId}}`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum {{{operationIdCamelCase}}}Success {
+    {{#responses}}
+    {{#is2xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is2xx}}
+    {{#is3xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is3xx}}
+    {{/responses}}
+    UnknownValue(serde_json::Value),
+}
+
+{{/operation}}
+{{/operations}}
+{{/supportMultipleResponses}}
+{{#operations}}
+{{#operation}}
+/// struct for typed errors of method [`{{operationId}}`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum {{{operationIdCamelCase}}}Error {
+    {{#responses}}
+    {{#is4xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is4xx}}
+    {{#is5xx}}
+    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/is5xx}}
+    {{#isDefault}}
+    DefaultResponse({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
+    {{/isDefault}}
+    {{/responses}}
+    UnknownValue(serde_json::Value),
+}
+
+{{/operation}}
+{{/operations}}
+
+{{#operations}}
+{{#operation}}
+{{#description}}
+/// {{{.}}}
+{{/description}}
+{{#notes}}
+/// {{{.}}}
+{{/notes}}
+{{#isDeprecated}}
+#[deprecated]
+{{/isDeprecated}}
+{{#vendorExtensions.x-group-parameters}}
+pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration{{#allParams}}{{#-first}}, {{!
+### Params
+}}params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}{{!
+### Function return type
+}}) -> Result<{{!
+### Response File Support
+}}{{#isResponseFile}}{{#supportAsync}}reqwest::Response{{/supportAsync}}{{^supportAsync}}reqwest::blocking::Response{{/supportAsync}}{{/isResponseFile}}{{!
+### Regular Responses
+}}{{^isResponseFile}}{{!
+### Multi response support
+}}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{!
+### Regular return type
+}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{/isResponseFile}}{{!
+### Error Type
+}}, Error<{{{operationIdCamelCase}}}Error>> {
+{{/vendorExtensions.x-group-parameters}}
+{{^vendorExtensions.x-group-parameters}}
+pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration, {{#allParams}}{{{paramName}}}: {{!
+### Option Start
+}}{{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{!
+### &str and Vec<&str>
+}}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{!
+### UUIDs
+}}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{!
+### Models and primative types
+}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{!
+### Option End
+}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{!
+### Comma for next arguement
+}}{{^-last}}, {{/-last}}{{/allParams}}{{!
+### Function return type
+}}) -> Result<{{!
+### Response File Support
+}}{{#isResponseFile}}{{#supportAsync}}reqwest::Response{{/supportAsync}}{{^supportAsync}}reqwest::blocking::Response{{/supportAsync}}{{/isResponseFile}}{{!
+### Regular Responses
+}}{{^isResponseFile}}{{!
+### Multi response support
+}}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{!
+### Regular return type
+}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{/isResponseFile}}{{!
+### Error Type
+}}, Error<{{{operationIdCamelCase}}}Error>> {
+    {{#allParams.0}}
+    // add a prefix to parameters to efficiently prevent name collisions
+    {{/allParams.0}}
+    {{#allParams}}
+    let {{{vendorExtensions.x-rust-param-identifier}}} = {{{paramName}}};
+    {{/allParams}}
+{{/vendorExtensions.x-group-parameters}}
+
+    let uri_str = format!("{}{{{path}}}", configuration.base_path{{#pathParams}}, {{{baseName}}}={{#isString}}crate::apis::urlencode({{/isString}}{{{vendorExtensions.x-rust-param-identifier}}}{{^required}}.unwrap(){{/required}}{{#required}}{{#isNullable}}.unwrap(){{/isNullable}}{{/required}}{{#isArray}}.join(",").as_ref(){{/isArray}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}.to_string(){{/isContainer}}{{/isPrimitiveType}}{{/isUuid}}{{/isString}}{{#isString}}){{/isString}}{{/pathParams}});
+    let mut req_builder = configuration.client.request(reqwest::Method::{{{httpMethod}}}, &uri_str);
+
+    {{#queryParams}}
+    {{#required}}
+    {{#isArray}}
+    req_builder = match "{{collectionFormat}}" {
+        "multi" => req_builder.query(&{{{vendorExtensions.x-rust-param-identifier}}}.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
+        _ => req_builder.query(&[("{{{baseName}}}", &{{{vendorExtensions.x-rust-param-identifier}}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+    };
+    {{/isArray}}
+    {{^isArray}}
+    {{^isNullable}}
+    req_builder = req_builder.query(&[("{{{baseName}}}", &{{{vendorExtensions.x-rust-param-identifier}}}.to_string())]);
+    {{/isNullable}}
+    {{#isNullable}}
+    {{#isDeepObject}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        {{^isExplode}}
+        let params = crate::apis::parse_deep_object("{{{baseName}}}", &serde_json::to_value(param_value)?);
+        req_builder = req_builder.query(&params);
+        {{/isExplode}}
+        {{#isExplode}}
+        {{#isModel}}
+        req_builder = req_builder.query(&param_value);
+        {{/isModel}}
+        {{#isMap}}
+        let mut query_params = Vec::with_capacity(param_value.len());
+        for (key, value) in param_value.iter() {
+            query_params.push((key.to_string(), serde_json::to_string(value)?));
+        }
+        req_builder = req_builder.query(&query_params);
+        {{/isMap}}
+        {{/isExplode}}
+    };
+    {{/isDeepObject}}
+    {{^isDeepObject}}
+    {{#isObject}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        req_builder = req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+    };
+    {{/isObject}}
+    {{#isModel}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        req_builder = req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+    };
+    {{/isModel}}
+    {{/isDeepObject}}
+    {{^isObject}}
+    {{^isModel}}
+    {{^isEnum}}
+    {{^isEnumRef}}
+    {{#isPrimitiveType}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        req_builder = req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
+    };
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        req_builder = req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+    };
+    {{/isPrimitiveType}}
+    {{/isEnumRef}}
+    {{/isEnum}}
+    {{#isEnum}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        req_builder = req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
+    };
+    {{/isEnum}}
+    {{#isEnumRef}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        req_builder = req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
+    };
+    {{/isEnumRef}}
+    {{/isModel}}
+    {{/isObject}}
+    {{/isNullable}}
+    {{/isArray}}
+    {{/required}}
+    {{^required}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        {{#isArray}}
+        req_builder = match "{{collectionFormat}}" {
+            "multi" => req_builder.query(&param_value.into_iter().map(|p| ("{{{baseName}}}".to_owned(), p.to_string())).collect::<Vec<(std::string::String, std::string::String)>>()),
+            _ => req_builder.query(&[("{{{baseName}}}", &param_value.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(",").to_string())]),
+        };
+        {{/isArray}}
+        {{^isArray}}
+        {{#isDeepObject}}
+        {{^isExplode}}
+        let params = crate::apis::parse_deep_object("{{{baseName}}}", &serde_json::to_value(param_value)?);
+        req_builder = req_builder.query(&params);
+        {{/isExplode}}
+        {{#isExplode}}
+        {{#isModel}}
+        req_builder = req_builder.query(&param_value);
+        {{/isModel}}
+        {{#isMap}}
+        let mut query_params = Vec::with_capacity(param_value.len());
+        for (key, value) in param_value.iter() {
+            query_params.push((key.to_string(), serde_json::to_string(value)?));
+        }
+        req_builder = req_builder.query(&query_params);
+        {{/isMap}}
+        {{/isExplode}}
+        {{/isDeepObject}}
+        {{^isDeepObject}}
+        {{#isObject}}
+        req_builder = req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+        {{/isObject}}
+        {{#isModel}}
+        req_builder = req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+        {{/isModel}}
+        {{#isEnum}}
+        req_builder = req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
+        {{/isEnum}}
+        {{#isEnumRef}}
+        req_builder = req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
+        {{/isEnumRef}}
+        {{^isObject}}
+        {{^isModel}}
+        {{^isEnum}}
+        {{^isEnumRef}}
+        {{#isPrimitiveType}}
+        req_builder = req_builder.query(&[("{{{baseName}}}", &param_value.to_string())]);
+        {{/isPrimitiveType}}
+        {{^isPrimitiveType}}
+        req_builder = req_builder.query(&[("{{{baseName}}}", &serde_json::to_string(param_value)?)]);
+        {{/isPrimitiveType}}
+        {{/isEnumRef}}
+        {{/isEnum}}
+        {{/isModel}}
+        {{/isObject}}
+        {{/isDeepObject}}
+        {{/isArray}}
+    }
+    {{/required}}
+    {{/queryParams}}
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#isApiKey}}
+    {{#isKeyInQuery}}
+    if let Some(apikey) = configuration.api_keys.get("{{{keyParamName}}}") {
+        let key = apikey.key.clone();
+        let value = match apikey.prefix {
+            Some(ref prefix) => format!("{} {}", prefix, key),
+            None => key,
+        };
+        req_builder = req_builder.query(&[("{{{keyParamName}}}", value)]);
+    }
+    {{/isKeyInQuery}}
+    {{/isApiKey}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+    {{#hasAuthMethods}}
+    {{#withAWSV4Signature}}
+    if let Some(ref aws_v4_key) = configuration.aws_v4_key {
+        let new_headers = match aws_v4_key.sign(
+	    &uri_str,
+	    "{{{httpMethod}}}",
+	    {{#hasBodyParam}}
+	    {{#bodyParams}}
+	    &serde_json::to_string(&{{{vendorExtensions.x-rust-param-identifier}}}).expect("param should serialize to string"),
+	    {{/bodyParams}}
+	    {{/hasBodyParam}}
+	    {{^hasBodyParam}}
+	    "",
+	    {{/hasBodyParam}}
+	    ) {
+	      Ok(new_headers) => new_headers,
+	      Err(err) => return Err(Error::AWSV4SignatureError(err)),
+	    };
+	for (name, value) in new_headers.iter() {
+	    req_builder = req_builder.header(name.as_str(), value.as_str());
+	}
+    }
+    {{/withAWSV4Signature}}
+    {{/hasAuthMethods}}
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+    }
+    {{#hasHeaderParams}}
+    {{#headerParams}}
+    {{#required}}
+    {{^isNullable}}
+    req_builder = req_builder.header("{{{baseName}}}", {{{vendorExtensions.x-rust-param-identifier}}}{{#isArray}}.join(","){{/isArray}}.to_string());
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{vendorExtensions.x-rust-param-identifier}}} {
+        Some(param_value) => { req_builder = req_builder.header("{{{baseName}}}", param_value{{#isArray}}.join(","){{/isArray}}.to_string()); },
+        None => { req_builder = req_builder.header("{{{baseName}}}", ""); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        req_builder = req_builder.header("{{{baseName}}}", param_value{{#isArray}}.join(","){{/isArray}}.to_string());
+    }
+    {{/required}}
+    {{/headerParams}}
+    {{/hasHeaderParams}}
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#supportTokenSource}}
+    // Obtain a token from source provider.
+    // Tokens can be Id or access tokens depending on the provider type and configuration.
+    let token = configuration.token_source.token().await.map_err(Error::TokenSource)?;
+    // The token format is the responsibility of the provider, thus we just set the authorization header with whatever is given.
+    req_builder = req_builder.header(reqwest::header::AUTHORIZATION, token);
+    {{/supportTokenSource}}
+    {{^supportTokenSource}}
+    {{#isApiKey}}
+    {{#isKeyInHeader}}
+    if let Some(apikey) = configuration.api_keys.get("{{{keyParamName}}}") {
+        let key = apikey.key.clone();
+        let value = match apikey.prefix {
+            Some(ref prefix) => format!("{} {}", prefix, key),
+            None => key,
+        };
+        req_builder = req_builder.header("{{{keyParamName}}}", value);
+    };
+    {{/isKeyInHeader}}
+    {{/isApiKey}}
+    {{#isBasic}}
+    {{#isBasicBasic}}
+    if let Some(ref auth_conf) = configuration.basic_auth {
+        req_builder = req_builder.basic_auth(auth_conf.0.to_owned(), auth_conf.1.to_owned());
+    };
+    {{/isBasicBasic}}
+    {{#isBasicBearer}}
+    if let Some(ref token) = configuration.bearer_access_token {
+        req_builder = req_builder.bearer_auth(token.to_owned());
+    };
+    {{/isBasicBearer}}
+    {{/isBasic}}
+    {{#isOAuth}}
+    if let Some(ref token) = configuration.oauth_access_token {
+        req_builder = req_builder.bearer_auth(token.to_owned());
+    };
+    {{/isOAuth}}
+    {{/supportTokenSource}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+    {{#isMultipart}}
+    {{#hasFormParams}}
+    let mut multipart_form = reqwest{{^supportAsync}}::blocking{{/supportAsync}}::multipart::Form::new();
+    {{#formParams}}
+    {{#isFile}}
+    {{^supportAsync}}
+    {{#required}}
+    {{^isNullable}}
+    {{#isArray}}
+    for value in &{{{vendorExtensions.x-rust-param-identifier}}} {
+        multipart_form = multipart_form.file("{{{baseName}}}", value)?;
+    }
+    {{/isArray}}
+    {{^isArray}}
+    multipart_form = multipart_form.file("{{{baseName}}}", {{{vendorExtensions.x-rust-param-identifier}}})?;
+    {{/isArray}}
+    {{/isNullable}}
+    {{#isNullable}}
+    {{#isArray}}
+    match {{{vendorExtensions.x-rust-param-identifier}}} {
+        Some(param_value) => {
+            for value in param_value {
+                multipart_form = multipart_form.file("{{{baseName}}}", value)?;
+            }
+        },
+        None => { unimplemented!("Required nullable form file param not supported"); },
+    }
+    {{/isArray}}
+    {{^isArray}}
+    match {{{vendorExtensions.x-rust-param-identifier}}} {
+        Some(param_value) => { multipart_form = multipart_form.file("{{{baseName}}}", param_value)?; },
+        None => { unimplemented!("Required nullable form file param not supported"); },
+    }
+    {{/isArray}}
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        {{#isArray}}
+        for value in param_value {
+            multipart_form = multipart_form.file("{{{baseName}}}", value)?;
+        }
+        {{/isArray}}
+        {{^isArray}}
+        multipart_form = multipart_form.file("{{{baseName}}}", param_value)?;
+        {{/isArray}}
+    }
+    {{/required}}
+    {{/supportAsync}}
+    {{#supportAsync}}
+    {{^required}}
+    if let Some(ref param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        {{#isArray}}
+                for value in param_value {
+                let file = TokioFile::open(value).await?;
+                let stream = FramedRead::new(file, BytesCodec::new());
+                let file_name = value.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+                let file_part = reqwest::multipart::Part::stream(reqwest::Body::wrap_stream(stream)).file_name(file_name);
+                multipart_form = multipart_form.part("{{{baseName}}}", file_part);
+                }
+        {{/isArray}}
+        {{^isArray}}
+                let file = TokioFile::open(param_value).await?;
+                let stream = FramedRead::new(file, BytesCodec::new());
+                let file_name = param_value.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+                let file_part = reqwest::multipart::Part::stream(reqwest::Body::wrap_stream(stream)).file_name(file_name);
+                multipart_form = multipart_form.part("{{{baseName}}}", file_part);
+        {{/isArray}}
+    }
+    {{/required}}
+    {{#required}}
+    {{#isArray}}
+    for value in &{{{vendorExtensions.x-rust-param-identifier}}} {
+        let file = TokioFile::open(value).await?;
+        let stream = FramedRead::new(file, BytesCodec::new());
+        let file_name = value.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+        let file_part = reqwest::multipart::Part::stream(reqwest::Body::wrap_stream(stream)).file_name(file_name);
+        multipart_form = multipart_form.part("{{{baseName}}}", file_part);
+    }
+    {{/isArray}}
+    {{^isArray}}
+    let file = TokioFile::open(&{{{vendorExtensions.x-rust-param-identifier}}}).await?;
+    let stream = FramedRead::new(file, BytesCodec::new());
+    let file_name = {{{vendorExtensions.x-rust-param-identifier}}}.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+    let file_part = reqwest::multipart::Part::stream(reqwest::Body::wrap_stream(stream)).file_name(file_name);
+    multipart_form = multipart_form.part("{{{baseName}}}", file_part);
+    {{/isArray}}
+    {{/required}}
+    {{/supportAsync}}
+    {{/isFile}}
+    {{^isFile}}
+    {{#required}}
+    {{^isNullable}}
+    multipart_form = multipart_form.text("{{{baseName}}}", {{{vendorExtensions.x-rust-param-identifier}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{vendorExtensions.x-rust-param-identifier}}} {
+        Some(param_value) => { multipart_form = multipart_form.text("{{{baseName}}}", param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+        None => { multipart_form = multipart_form.text("{{{baseName}}}", ""); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+    {{#isPrimitiveType}}
+        multipart_form = multipart_form.text("{{{baseName}}}", param_value.to_string());
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+        multipart_form = multipart_form.text("{{{baseName}}}", serde_json::to_string(&param_value)?);
+    {{/isPrimitiveType}}
+    }
+    {{/required}}
+    {{/isFile}}
+    {{/formParams}}
+    req_builder = req_builder.multipart(multipart_form);
+    {{/hasFormParams}}
+    {{/isMultipart}}
+    {{^isMultipart}}
+    {{#hasFormParams}}
+    let mut multipart_form_params = std::collections::HashMap::new();
+    {{#formParams}}
+    {{#isFile}}
+    {{#required}}
+    {{^isNullable}}
+    multipart_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{vendorExtensions.x-rust-param-identifier}}} {
+        Some(param_value) => { multipart_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content")); },
+        None => { unimplemented!("Required nullable file form param not supported with x-www-form-urlencoded content"); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        multipart_form_params.insert("{{{baseName}}}", unimplemented!("File form param not supported with x-www-form-urlencoded content"));
+    }
+    {{/required}}
+    {{/isFile}}
+    {{^isFile}}
+    {{#required}}
+    {{^isNullable}}
+    multipart_form_params.insert("{{{baseName}}}", {{{vendorExtensions.x-rust-param-identifier}}}{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    {{/isNullable}}
+    {{#isNullable}}
+    match {{{vendorExtensions.x-rust-param-identifier}}} {
+        Some(param_value) => { multipart_form_params.insert("{{{baseName}}}", param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string()); },
+        None => { multipart_form_params.insert("{{{baseName}}}", ""); },
+    }
+    {{/isNullable}}
+    {{/required}}
+    {{^required}}
+    if let Some(param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        multipart_form_params.insert("{{{baseName}}}", param_value{{#isArray}}.into_iter().map(|p| p.to_string()).collect::<Vec<String>>().join(","){{/isArray}}.to_string());
+    }
+    {{/required}}
+    {{/isFile}}
+    {{/formParams}}
+    req_builder = req_builder.form(&multipart_form_params);
+    {{/hasFormParams}}
+    {{/isMultipart}}
+    {{#hasBodyParam}}
+    {{#bodyParams}}
+    {{#isFile}}
+    {{#supportAsync}}
+    {{#required}}
+    let file = TokioFile::open({{{vendorExtensions.x-rust-param-identifier}}}).await?;
+    let stream = FramedRead::new(file, BytesCodec::new());
+    req_builder = req_builder.body(reqwest::Body::wrap_stream(stream));
+    {{/required}}
+    {{^required}}
+    if let Some(param_value) = {{{vendorExtensions.x-rust-param-identifier}}} {
+        let file = TokioFile::open(param_value).await?;
+        let stream = FramedRead::new(file, BytesCodec::new());
+        req_builder = req_builder.body(reqwest::Body::wrap_stream(stream));
+    }
+    {{/required}}
+    {{/supportAsync}}
+    {{^supportAsync}}
+    req_builder = req_builder.body({{{vendorExtensions.x-rust-param-identifier}}});
+    {{/supportAsync}}
+    {{/isFile}}
+    {{^isFile}}
+    req_builder = req_builder.json(&{{{vendorExtensions.x-rust-param-identifier}}});
+    {{/isFile}}
+    {{/bodyParams}}
+    {{/hasBodyParam}}
+
+    let req = req_builder.build()?;
+    let resp = configuration.client.execute(req){{#supportAsync}}.await{{/supportAsync}}?;
+
+    let status = resp.status();
+    {{^supportMultipleResponses}}
+    {{^isResponseFile}}
+    {{#returnType}}
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
+    {{/returnType}}
+    {{/isResponseFile}}
+    {{/supportMultipleResponses}}
+
+    if !status.is_client_error() && !status.is_server_error() {
+        {{^supportMultipleResponses}}
+        {{#isResponseFile}}
+        Ok(resp)
+        {{/isResponseFile}}
+        {{^isResponseFile}}
+        {{^returnType}}
+        Ok(())
+        {{/returnType}}
+        {{#returnType}}
+        let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        match content_type {
+            {{^useSerdePathToError}}
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            {{/useSerdePathToError}}
+            {{#useSerdePathToError}}
+            ContentType::Json => serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_str(&content)).map_err(Error::from),
+            {{/useSerdePathToError}}
+            {{#vendorExtensions.x-supports-plain-text}}
+            ContentType::Text => return Ok(content),
+            {{/vendorExtensions.x-supports-plain-text}}
+            {{^vendorExtensions.x-supports-plain-text}}
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `{{returnType}}`"))),
+            {{/vendorExtensions.x-supports-plain-text}}
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `{{returnType}}`")))),
+        }
+        {{/returnType}}
+        {{/isResponseFile}}
+        {{/supportMultipleResponses}}
+        {{#supportMultipleResponses}}
+        {{#isResponseFile}}
+        Ok(resp)
+        {{/isResponseFile}}
+        {{^isResponseFile}}
+        let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        let entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&content).ok();
+        Ok(ResponseContent { status, content, entity })
+        {{/isResponseFile}}
+        {{/supportMultipleResponses}}
+    } else {
+        let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        let entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent { status, content, entity }))
+    }
+}
+
+{{/operation}}
+{{/operations}}

--- a/.openapi-generator-templates/reqwest/configuration.mustache
+++ b/.openapi-generator-templates/reqwest/configuration.mustache
@@ -1,0 +1,123 @@
+{{>partial_header}}
+
+use std::collections::HashMap;
+{{#withAWSV4Signature}}
+use std::time::SystemTime;
+use aws_sigv4::http_request::{sign, SigningSettings, SigningParams, SignableRequest};
+use http;
+use secrecy::{SecretString, ExposeSecret};
+{{/withAWSV4Signature}}
+{{#supportTokenSource}}
+use std::sync::Arc;
+use google_cloud_token::TokenSource;
+use async_trait::async_trait;
+{{/supportTokenSource}}
+
+#[derive(Debug, Clone)]
+pub struct Configuration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub client: {{#supportMiddleware}}reqwest_middleware::ClientWithMiddleware{{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client{{/supportMiddleware}},
+    {{^supportTokenSource}}
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_keys: HashMap<String, ApiKey>,
+    {{/supportTokenSource}}
+    {{#withAWSV4Signature}}
+    pub aws_v4_key: Option<AWSv4Key>,
+    {{/withAWSV4Signature}}
+    {{#supportAsync}}
+    {{#supportTokenSource}}
+    pub token_source: Arc<dyn TokenSource>,
+    {{/supportTokenSource}}
+    {{/supportAsync}}
+}
+{{^supportTokenSource}}
+
+pub type BasicAuth = (String, Option<String>);
+
+#[derive(Debug, Clone)]
+pub struct ApiKey {
+    pub prefix: Option<String>,
+    pub key: String,
+}
+{{/supportTokenSource}}
+
+{{#withAWSV4Signature}}
+#[derive(Debug, Clone)]
+pub struct AWSv4Key {
+    pub access_key: String,
+    pub secret_key: SecretString,
+    pub region: String,
+    pub service: String,
+}
+
+impl AWSv4Key {
+    pub fn sign(&self, uri: &str, method: &str, body: &str) -> Result<Vec::<(String, String)>, aws_sigv4::http_request::Error> {
+	let request = http::Request::builder()
+	    .uri(uri)
+	    .method(method)
+	    .body(body).unwrap();
+	let signing_settings = SigningSettings::default();
+	let signing_params = SigningParams::builder()
+	    .access_key(self.access_key.as_str())
+	    .secret_key(self.secret_key.expose_secret().as_str())
+	    .region(self.region.as_str())
+	    .service_name(self.service.as_str())
+	    .time(SystemTime::now())
+	    .settings(signing_settings)
+	    .build()
+	    .unwrap();
+	let signable_request = SignableRequest::from(&request);
+	let (mut signing_instructions, _signature) = sign(signable_request, &signing_params)?.into_parts();
+	let mut additional_headers = Vec::<(String, String)>::new();
+	if let Some(new_headers) = signing_instructions.take_headers() {
+            for (name, value) in new_headers.into_iter() {
+		additional_headers.push((name.expect("header should have name").to_string(),
+		                         value.to_str().expect("header value should be a string").to_string()));
+            }
+        }
+	Ok(additional_headers)
+    }
+}
+{{/withAWSV4Signature}}
+
+impl Configuration {
+    pub fn new() -> Configuration {
+        Configuration::default()
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            base_path: "{{{basePath}}}".to_owned(),
+            user_agent: {{#httpUserAgent}}Some("{{{.}}}".to_owned()){{/httpUserAgent}}{{^httpUserAgent}}Some("OpenAPI-Generator/{{{version}}}/rust".to_owned()){{/httpUserAgent}},
+            client: {{#supportMiddleware}}reqwest_middleware::ClientBuilder::new(reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client::new()).build(){{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client::new(){{/supportMiddleware}},
+            {{^supportTokenSource}}
+            basic_auth: None,
+            oauth_access_token: None,
+            bearer_access_token: None,
+            api_keys: HashMap::new(),
+            {{/supportTokenSource}}
+            {{#withAWSV4Signature}}
+            aws_v4_key: None,
+            {{/withAWSV4Signature}}
+            {{#supportTokenSource}}
+            token_source: Arc::new(NoopTokenSource{}),
+            {{/supportTokenSource}}
+        }
+    }
+}
+{{#supportTokenSource}}
+#[derive(Debug)]
+struct NoopTokenSource{}
+
+#[async_trait]
+impl TokenSource for NoopTokenSource {
+    async fn token(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        panic!("This is dummy token source. You can use TokenSourceProvider from 'google_cloud_auth' crate, or any other compatible crate.")
+    }
+}
+{{/supportTokenSource}}


### PR DESCRIPTION
Stock openapi-generator-rust collapses multiple apiKey security schemes onto a single `Configuration.api_key` field, so `X-Workspace-Id` and `X-Session-Id` would get the same value. Override replaces it with `api_keys: HashMap<String, ApiKey>` keyed by header name. Same fix as upstream PR #19511 (closed pending a generator flag). `cargo check` in the regen workflow is the drift tripwire.