### PR TITLE
chore(ci): bump Node 20 actions to Node 24 runtime

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3.2.0
         with:
           app-id: 3060111
           private-key: ${{ secrets.HOTDATA_AUTOMATION_PRIVATE_KEY }}
           owner: hotdata-dev
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -56,7 +56,7 @@ jobs:
         run: cargo check
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "chore: regenerate client from updated OpenAPI spec"


### PR DESCRIPTION
Bump three GitHub Actions to their Node 24 runtime releases in the regenerate workflow.

Bumps:
- actions/create-github-app-token: v2 -> v3.2.0
- actions/checkout: v4 -> v6.0.2
- peter-evans/create-pull-request: v6 -> v8.1.1

Breaking changes to review:
- actions/create-github-app-token v2->v3.2.0: v3 drops Node 20 in favor of Node 24 runtime; token generation behavior unchanged; inputs used here (app-id, private-key, owner) unaffected.
- actions/checkout v4->v6.0.2: v4->v6 bumps runtime to Node 24 and updates internal deps; v5 dropped Node 20 support; token/with inputs used here unchanged.
- peter-evans/create-pull-request v6->v8.1.1: v6->v8 migrates to Node 24; v7 changed default branch/sign-commits behavior and removed some deprecated inputs; inputs used here (token, title, branch, commit-message, body) remain supported.