### PR TITLE
feat(ci): use generated title for regen PR

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -2,6 +2,15 @@ name: Regenerate Client
 
 on:
   workflow_dispatch:
+    inputs:
+      title:
+        description: PR title, auto-generated from the spec diff in www.
+        required: false
+        type: string
+      summary:
+        description: PR body summarizing the spec changes.
+        required: false
+        type: string
 
 jobs:
   regenerate:
@@ -59,7 +68,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
-          title: "chore: regenerate client from updated OpenAPI spec"
+          title: "${{ inputs.title || 'chore: regenerate client from updated OpenAPI spec' }}"
           branch: openapi-update-${{ github.run_id }}
-          commit-message: "chore: regenerate client from OpenAPI spec"
-          body: "Auto-generated from updated HotData OpenAPI spec."
+          commit-message: "${{ inputs.title || 'chore: regenerate client from OpenAPI spec' }}"
+          body: "${{ inputs.summary || 'Auto-generated from updated HotData OpenAPI spec.' }}"


### PR DESCRIPTION
Accepts `title`/`summary` workflow_dispatch inputs from www's notify-sdks so regeneration PRs reflect the actual API changes, falling back to the static title for manual runs.