### PR TITLE
feat: ergonomic surface for CLI consumption (attribution, async query, streaming upload)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tokio-util = { version = "^0.7", features = ["codec"] }
 reqwest = { version = "^0.13", default-features = false, features = ["json", "multipart", "stream", "query", "form"] }
 async-trait = "^0.1"
 bytes = "^1"
+futures-core = "^0.3"
 log = "^0.4"
 arrow-ipc = { version = "55", optional = true }
 arrow-array = { version = "55", optional = true }
@@ -30,6 +31,7 @@ arrow = ["dep:arrow-ipc", "dep:arrow-array", "dep:arrow-schema"]
 
 [dev-dependencies]
 tokio = { version = "^1.46.0", features = ["rt-multi-thread", "macros", "time"] }
+futures = "^0.3"
 wiremock = "0.6"
 uuid = { version = "1", features = ["v4"] }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -39,6 +39,7 @@
 //!   with a bounded per-request timeout so a stalled token endpoint fails fast
 //!   instead of hanging every call.
 
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
@@ -122,6 +123,72 @@ pub trait BearerTokenProvider: Send + Sync + std::fmt::Debug {
     async fn bearer_value(&self) -> Result<String, TokenExchangeError>;
 }
 
+/// Callback fired after a successful mint so a host (e.g. the CLI) can persist
+/// the rotated tokens across process invocations.
+///
+/// Invoked with `(access_token, refresh_token, exp)` where `exp` is the
+/// absolute unix-epoch expiry (seconds). `refresh_token` is `None` when the
+/// server omitted one (rotation off; the prior refresh token is carried
+/// forward and the callback is still given `None` to reflect the wire
+/// response). The callback must return quickly and must not re-enter the
+/// [`TokenManager`] (it runs while the single-flight lock is held).
+pub type PersistCallback = Arc<dyn Fn(&str, Option<&str>, u64) + Send + Sync>;
+
+/// Tuning for [`TokenManager::with_options`].
+///
+/// The default preserves the historical [`TokenManager::new`] behavior exactly:
+/// `client_id = CLIENT_ID` (`hotdata-rust-sdk`), `token_path = /v1/auth/jwt`,
+/// empty `base_path`, no seed, and no persistence callback. Hosts that mint
+/// under a different attribution (e.g. the CLI's `hotdata-cli` at `/o/token/`)
+/// or that need to seed an existing session and persist rotations override the
+/// relevant fields.
+#[non_exhaustive]
+pub struct TokenManagerOptions {
+    /// `client_id` form param sent with every mint. Defaults to [`CLIENT_ID`].
+    pub client_id: String,
+    /// Path appended to `base_path` for the mint endpoint. Defaults to
+    /// `/v1/auth/jwt`.
+    pub token_path: String,
+    /// API base URL the mint POSTs to (e.g. `https://api.hotdata.dev`). The
+    /// builder fills this from the resolved base path.
+    pub base_path: String,
+    /// Optional refresh token to seed the cache with, so the first request can
+    /// take the refresh path instead of re-minting from the API token.
+    pub seed_refresh: Option<String>,
+    /// Optional `(jwt, exp)` to seed the cache with a known-valid JWT (absolute
+    /// unix-epoch expiry in seconds), avoiding a mint on the first request.
+    pub seed_jwt: Option<(String, u64)>,
+    /// Optional callback fired after each successful mint so the host can
+    /// persist the rotated tokens.
+    pub on_persist: Option<PersistCallback>,
+}
+
+impl Default for TokenManagerOptions {
+    fn default() -> Self {
+        TokenManagerOptions {
+            client_id: CLIENT_ID.to_string(),
+            token_path: "/v1/auth/jwt".to_string(),
+            base_path: String::new(),
+            seed_refresh: None,
+            seed_jwt: None,
+            on_persist: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for TokenManagerOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenManagerOptions")
+            .field("client_id", &self.client_id)
+            .field("token_path", &self.token_path)
+            .field("base_path", &self.base_path)
+            .field("seed_refresh", &self.seed_refresh.as_ref().map(|_| "<redacted>"))
+            .field("seed_jwt", &self.seed_jwt.as_ref().map(|(_, exp)| ("<redacted>", exp)))
+            .field("on_persist", &self.on_persist.as_ref().map(|_| "<fn>"))
+            .finish()
+    }
+}
+
 /// Token-exchange response (`POST /v1/auth/jwt`). Mirrors the CLI's
 /// `TokenResponse` and the OAuth token-grant shape.
 #[derive(Deserialize)]
@@ -144,7 +211,6 @@ struct TokenState {
 /// A credential that already looks like a JWT (`eyJ` prefix) is passed through
 /// unchanged, as is any credential when `HOTDATA_DISABLE_JWT_EXCHANGE` is set
 /// to an affirmative value; every other (opaque) API token is exchanged.
-#[derive(Debug)]
 pub struct TokenManager {
     /// The user-supplied credential (API token, or a literal JWT to pass through).
     credential: String,
@@ -152,8 +218,27 @@ pub struct TokenManager {
     client: reqwest::Client,
     /// API host the exchange POSTs to; read at mint time.
     base_path: String,
+    /// Path appended to `base_path` for the mint endpoint (default `/v1/auth/jwt`).
+    token_path: String,
+    /// `client_id` form param sent with every mint (default [`CLIENT_ID`]).
+    client_id: String,
+    /// Optional callback fired after a successful mint so the host can persist
+    /// rotated tokens across invocations.
+    on_persist: Option<PersistCallback>,
     /// Cached JWT + refresh token, guarded for single-flight minting.
     state: Mutex<TokenState>,
+}
+
+impl std::fmt::Debug for TokenManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenManager")
+            .field("credential", &"<redacted>")
+            .field("base_path", &self.base_path)
+            .field("token_path", &self.token_path)
+            .field("client_id", &self.client_id)
+            .field("on_persist", &self.on_persist.as_ref().map(|_| "<fn>"))
+            .finish()
+    }
 }
 
 impl TokenManager {
@@ -169,11 +254,49 @@ impl TokenManager {
         client: reqwest::Client,
         base_path: impl Into<String>,
     ) -> Self {
+        TokenManager::with_options(
+            credential,
+            client,
+            TokenManagerOptions {
+                base_path: base_path.into(),
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Build a token manager with explicit [`TokenManagerOptions`].
+    ///
+    /// Equivalent to [`TokenManager::new`] when `opts` is `Default::default()`
+    /// with `base_path` set. Use this to override the mint attribution
+    /// (`client_id`/`token_path`), seed an existing JWT or refresh token, or
+    /// install an `on_persist` callback that survives rotation across process
+    /// invocations.
+    ///
+    /// * `credential` -- the user's API token (or a literal `eyJ...` JWT).
+    /// * `client` -- the SDK's configured reqwest client; cloned in so the
+    ///   exchange reuses the same TLS/proxy/connection pool.
+    /// * `opts` -- mint attribution, seed values, and persistence callback.
+    pub fn with_options(
+        credential: impl Into<String>,
+        client: reqwest::Client,
+        opts: TokenManagerOptions,
+    ) -> Self {
+        let mut state = TokenState::default();
+        if let Some(refresh) = opts.seed_refresh {
+            state.refresh = Some(refresh);
+        }
+        if let Some((jwt, exp)) = opts.seed_jwt {
+            state.jwt = Some(jwt);
+            state.exp = exp;
+        }
         TokenManager {
             credential: credential.into(),
             client,
-            base_path: base_path.into(),
-            state: Mutex::new(TokenState::default()),
+            base_path: opts.base_path,
+            token_path: opts.token_path,
+            client_id: opts.client_id,
+            on_persist: opts.on_persist,
+            state: Mutex::new(state),
         }
     }
 
@@ -197,9 +320,13 @@ impl TokenManager {
     /// decides whether a given grant is best-effort (refresh) or hard
     /// (api_token).
     async fn mint(&self, grant: &[(&str, &str)]) -> Result<TokenResponse, TokenExchangeError> {
-        let url = format!("{}/v1/auth/jwt", self.base_path.trim_end_matches('/'));
+        let url = format!(
+            "{}{}",
+            self.base_path.trim_end_matches('/'),
+            self.token_path
+        );
         let mut params: Vec<(&str, &str)> = grant.to_vec();
-        params.push(("client_id", CLIENT_ID));
+        params.push(("client_id", &self.client_id));
 
         let resp = self
             .client
@@ -239,6 +366,23 @@ impl TokenManager {
         }
         // else: keep the existing refresh token (carry-forward).
     }
+
+    /// Apply a successful mint and, if configured, fire the persistence
+    /// callback with the freshly minted tokens.
+    ///
+    /// The callback receives the wire `refresh_token` (`None` when the server
+    /// omitted one) and the absolute expiry written into the cache, so a host
+    /// can persist exactly what landed. It runs while the single-flight lock is
+    /// held, so it must be quick and non-reentrant.
+    fn apply_and_persist(&self, state: &mut TokenState, resp: TokenResponse) {
+        let wire_refresh = resp.refresh_token.clone();
+        Self::apply(state, resp);
+        if let Some(cb) = &self.on_persist {
+            if let Some(jwt) = &state.jwt {
+                cb(jwt, wire_refresh.as_deref(), state.exp);
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -269,7 +413,7 @@ impl BearerTokenProvider for TokenManager {
                 .mint(&[("grant_type", "refresh_token"), ("refresh_token", &refresh)])
                 .await
             {
-                Ok(resp) => Self::apply(&mut state, resp),
+                Ok(resp) => self.apply_and_persist(&mut state, resp),
                 Err(_) => state.refresh = None,
             }
         }
@@ -284,7 +428,7 @@ impl BearerTokenProvider for TokenManager {
             let resp = self
                 .mint(&[("grant_type", "api_token"), ("api_token", &self.credential)])
                 .await?;
-            Self::apply(&mut state, resp);
+            self.apply_and_persist(&mut state, resp);
         }
 
         // apply() always sets jwt on a successful mint; unwrap is safe because
@@ -678,5 +822,226 @@ mod tests {
         let base = format!("{}/", server.uri());
         let m = manager("hd_opaque", &base);
         assert_eq!(m.bearer_value().await.unwrap(), "ok");
+    }
+
+    // --- TokenManagerOptions: defaults, attribution, seed, persist ---------
+
+    #[test]
+    fn new_matches_default_options() {
+        // new() must be byte-for-byte equivalent to with_options(.., Default)
+        // with base_path set: same client_id, token_path, no seed, no persist.
+        let m = TokenManager::new("hd_opaque", reqwest::Client::new(), "https://api.example.dev");
+        assert_eq!(m.client_id, CLIENT_ID);
+        assert_eq!(m.token_path, "/v1/auth/jwt");
+        assert_eq!(m.base_path, "https://api.example.dev");
+        assert!(m.on_persist.is_none());
+    }
+
+    #[test]
+    fn options_default_preserves_legacy_attribution() {
+        let opts = TokenManagerOptions::default();
+        assert_eq!(opts.client_id, CLIENT_ID);
+        assert_eq!(opts.token_path, "/v1/auth/jwt");
+        assert!(opts.base_path.is_empty());
+        assert!(opts.seed_refresh.is_none());
+        assert!(opts.seed_jwt.is_none());
+        assert!(opts.on_persist.is_none());
+    }
+
+    #[tokio::test]
+    async fn seed_jwt_is_served_without_minting() {
+        let _g = EnvGuard::unset();
+        // A seeded, still-valid JWT must be returned from the fast path; the
+        // dead port proves no mint happened.
+        let m = TokenManager::with_options(
+            "hd_opaque",
+            reqwest::Client::new(),
+            TokenManagerOptions {
+                base_path: "http://127.0.0.1:1".into(),
+                seed_jwt: Some(("seeded-jwt".into(), now_unix() + 600)),
+                ..Default::default()
+            },
+        );
+        assert_eq!(m.bearer_value().await.unwrap(), "seeded-jwt");
+    }
+
+    #[tokio::test]
+    async fn seed_refresh_drives_refresh_grant_first() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = EnvGuard::unset();
+        let server = MockServer::start().await;
+        // Only the refresh grant is mounted; if the manager re-minted from the
+        // api_token instead, the request would 404 and surface an error.
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/jwt"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .and(body_string_contains("refresh_token=seeded-refresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "from-seeded-refresh",
+                "expires_in": 300
+            })))
+            .mount(&server)
+            .await;
+
+        let m = TokenManager::with_options(
+            "hd_opaque",
+            reqwest::Client::new(),
+            TokenManagerOptions {
+                base_path: server.uri(),
+                seed_refresh: Some("seeded-refresh".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(m.bearer_value().await.unwrap(), "from-seeded-refresh");
+    }
+
+    #[tokio::test]
+    async fn configurable_client_id_and_token_path_hit_the_wire() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = EnvGuard::unset();
+        let server = MockServer::start().await;
+        // Mint must POST to the configured path with the configured client_id
+        // (the CLI's `hotdata-cli` at `/o/token/`), NOT the SDK defaults.
+        Mock::given(method("POST"))
+            .and(path("/o/token/"))
+            .and(body_string_contains("client_id=hotdata-cli"))
+            .and(body_string_contains("grant_type=api_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "cli-minted",
+                "expires_in": 300
+            })))
+            .mount(&server)
+            .await;
+
+        let m = TokenManager::with_options(
+            "hd_opaque",
+            reqwest::Client::new(),
+            TokenManagerOptions {
+                base_path: server.uri(),
+                client_id: "hotdata-cli".into(),
+                token_path: "/o/token/".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(m.bearer_value().await.unwrap(), "cli-minted");
+    }
+
+    #[tokio::test]
+    async fn on_persist_fires_on_mint_with_rotated_tokens() {
+        use std::sync::Mutex as StdMutex;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = EnvGuard::unset();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/jwt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "minted-jwt",
+                "expires_in": 300,
+                "refresh_token": "rotated-refresh"
+            })))
+            .mount(&server)
+            .await;
+
+        // Capture what the callback was handed.
+        let captured: Arc<StdMutex<Option<(String, Option<String>, u64)>>> =
+            Arc::new(StdMutex::new(None));
+        let sink = captured.clone();
+        let cb: PersistCallback = Arc::new(move |jwt: &str, refresh: Option<&str>, exp: u64| {
+            *sink.lock().unwrap() = Some((jwt.to_string(), refresh.map(str::to_string), exp));
+        });
+
+        let before = now_unix();
+        let m = TokenManager::with_options(
+            "hd_opaque",
+            reqwest::Client::new(),
+            TokenManagerOptions {
+                base_path: server.uri(),
+                on_persist: Some(cb),
+                ..Default::default()
+            },
+        );
+        assert_eq!(m.bearer_value().await.unwrap(), "minted-jwt");
+
+        let got = captured.lock().unwrap().clone().expect("on_persist must fire");
+        assert_eq!(got.0, "minted-jwt");
+        assert_eq!(got.1.as_deref(), Some("rotated-refresh"));
+        assert!(got.2 >= before + 300, "exp should be ~now+expires_in");
+    }
+
+    #[tokio::test]
+    async fn on_persist_reports_none_refresh_when_server_omits_it() {
+        use std::sync::Mutex as StdMutex;
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = EnvGuard::unset();
+        let server = MockServer::start().await;
+        // Refresh grant succeeds but omits a new refresh token (rotation off).
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/jwt"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "refreshed-jwt",
+                "expires_in": 300
+            })))
+            .mount(&server)
+            .await;
+
+        let captured: Arc<StdMutex<Option<Option<String>>>> = Arc::new(StdMutex::new(None));
+        let sink = captured.clone();
+        let cb: PersistCallback = Arc::new(move |_jwt: &str, refresh: Option<&str>, _exp: u64| {
+            *sink.lock().unwrap() = Some(refresh.map(str::to_string));
+        });
+
+        let m = TokenManager::with_options(
+            "hd_opaque",
+            reqwest::Client::new(),
+            TokenManagerOptions {
+                base_path: server.uri(),
+                seed_refresh: Some("seeded".into()),
+                on_persist: Some(cb),
+                ..Default::default()
+            },
+        );
+        assert_eq!(m.bearer_value().await.unwrap(), "refreshed-jwt");
+        // The wire response omitted refresh_token -> callback sees None, even
+        // though the cache carries the prior refresh token forward.
+        assert_eq!(captured.lock().unwrap().clone(), Some(None));
+        assert_eq!(m.state.lock().await.refresh.as_deref(), Some("seeded"));
+    }
+
+    #[tokio::test]
+    async fn on_persist_does_not_fire_for_seeded_jwt_fast_path() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _g = EnvGuard::unset();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let sink = calls.clone();
+        let cb: PersistCallback = Arc::new(move |_: &str, _: Option<&str>, _: u64| {
+            sink.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let m = TokenManager::with_options(
+            "hd_opaque",
+            reqwest::Client::new(),
+            TokenManagerOptions {
+                base_path: "http://127.0.0.1:1".into(),
+                seed_jwt: Some(("seeded".into(), now_unix() + 600)),
+                on_persist: Some(cb),
+                ..Default::default()
+            },
+        );
+        assert_eq!(m.bearer_value().await.unwrap(), "seeded");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "no mint occurred, so on_persist must not fire"
+        );
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -127,10 +127,12 @@ pub trait BearerTokenProvider: Send + Sync + std::fmt::Debug {
 /// the rotated tokens across process invocations.
 ///
 /// Invoked with `(access_token, refresh_token, exp)` where `exp` is the
-/// absolute unix-epoch expiry (seconds). `refresh_token` is `None` when the
-/// server omitted one (rotation off; the prior refresh token is carried
-/// forward and the callback is still given `None` to reflect the wire
-/// response). The callback must return quickly and must not re-enter the
+/// absolute unix-epoch expiry (seconds). `refresh_token` is the *effective*
+/// refresh token now in the cache: a freshly rotated one when the server
+/// returns it, otherwise the prior token carried forward (so the callback is
+/// handed a complete, persistable credential set rather than `None`). It is
+/// only `None` if no refresh token has ever been established. The callback
+/// must return quickly and must not re-enter the
 /// [`TokenManager`] (it runs while the single-flight lock is held).
 pub type PersistCallback = Arc<dyn Fn(&str, Option<&str>, u64) + Send + Sync>;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -370,16 +370,16 @@ impl TokenManager {
     /// Apply a successful mint and, if configured, fire the persistence
     /// callback with the freshly minted tokens.
     ///
-    /// The callback receives the wire `refresh_token` (`None` when the server
-    /// omitted one) and the absolute expiry written into the cache, so a host
-    /// can persist exactly what landed. It runs while the single-flight lock is
-    /// held, so it must be quick and non-reentrant.
+    /// The callback receives the *effective* refresh token (the one now in the
+    /// cache, which carries the prior token forward when the server omits a new
+    /// one) and the absolute expiry written into the cache, so a host can
+    /// persist a complete, usable credential set. It runs while the
+    /// single-flight lock is held, so it must be quick and non-reentrant.
     fn apply_and_persist(&self, state: &mut TokenState, resp: TokenResponse) {
-        let wire_refresh = resp.refresh_token.clone();
         Self::apply(state, resp);
         if let Some(cb) = &self.on_persist {
             if let Some(jwt) = &state.jwt {
-                cb(jwt, wire_refresh.as_deref(), state.exp);
+                cb(jwt, state.refresh.as_deref(), state.exp);
             }
         }
     }
@@ -978,7 +978,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn on_persist_reports_none_refresh_when_server_omits_it() {
+    async fn on_persist_carries_refresh_forward_when_server_omits_it() {
         use std::sync::Mutex as StdMutex;
         use wiremock::matchers::{body_string_contains, method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1013,9 +1013,10 @@ mod tests {
             },
         );
         assert_eq!(m.bearer_value().await.unwrap(), "refreshed-jwt");
-        // The wire response omitted refresh_token -> callback sees None, even
-        // though the cache carries the prior refresh token forward.
-        assert_eq!(captured.lock().unwrap().clone(), Some(None));
+        // The wire response omitted refresh_token, so the cache carries the
+        // prior refresh token forward -> the callback sees that effective
+        // token (not None), so a host persists a complete credential set.
+        assert_eq!(captured.lock().unwrap().clone(), Some(Some("seeded".to_string())));
         assert_eq!(m.state.lock().await.refresh.as_deref(), Some("seeded"));
     }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -472,7 +472,10 @@ mod tests {
     /// var on construction, and removes it on drop. The lock guarantees no two
     /// env-mutating tests run concurrently even though `cargo test` runs test
     /// functions on parallel threads.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Shared crate-wide env lock (see crate::ENV_LOCK) so env-mutating tests in
+    // other modules (e.g. client.rs) cannot run concurrently with these and
+    // race on process-global vars like DISABLE_ENV.
+    use crate::ENV_LOCK;
 
     struct EnvGuard {
         _lock: std::sync::MutexGuard<'static, ()>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,7 +27,7 @@ use std::env;
 
 use crate::apis::configuration::{ApiKey, Configuration};
 use crate::apis::{self, Error};
-use crate::auth::TokenManager;
+use crate::auth::{TokenManager, TokenManagerOptions};
 use crate::models;
 
 /// Default API host. Matches the generated `Configuration::default()` base
@@ -101,6 +101,7 @@ pub struct ClientBuilder {
     session_id: Option<String>,
     base_url: Option<String>,
     user_agent: Option<String>,
+    client_id: Option<String>,
     reqwest_client: Option<reqwest::Client>,
 }
 
@@ -138,6 +139,15 @@ impl ClientBuilder {
     /// Override the `User-Agent` header. Defaults to `hotdata-rust/<crate version>`.
     pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
         self.user_agent = Some(user_agent.into());
+        self
+    }
+
+    /// Override the `client_id` sent with every token-exchange (JWT mint)
+    /// request. Defaults to the SDK's identifier (`hotdata-rust-sdk`). Set this
+    /// so token traffic is attributed to the host application (e.g.
+    /// `hotdata-cli`) rather than the SDK.
+    pub fn client_id(mut self, client_id: impl Into<String>) -> Self {
+        self.client_id = Some(client_id.into());
         self
     }
 
@@ -222,8 +232,21 @@ impl ClientBuilder {
         // Install the transparent api_token -> JWT exchange. The TokenManager
         // reuses the same reqwest client (so TLS/proxy/timeout settings are
         // shared) and the resolved base path (so the JWT mint targets the API
-        // host, honoring any test override).
-        let token_manager = TokenManager::new(api_token, http_client, base_path);
+        // host, honoring any test override). A caller-supplied client_id
+        // attributes the token traffic to the host app; otherwise the SDK
+        // default applies.
+        let token_manager = TokenManager::with_options(
+            api_token,
+            http_client,
+            TokenManagerOptions {
+                base_path,
+                client_id: self
+                    .client_id
+                    .clone()
+                    .unwrap_or_else(|| TokenManagerOptions::default().client_id),
+                ..TokenManagerOptions::default()
+            },
+        );
         configuration.token_provider = Some(std::sync::Arc::new(token_manager));
 
         Ok(Client { configuration })
@@ -710,9 +733,48 @@ mod tests {
             ENV_API_URL,
             ENV_TEST_API_URL,
             "HOTDATA_SESSION_ID",
+            "HOTDATA_DISABLE_JWT_EXCHANGE",
         ] {
             env::remove_var(key);
         }
+    }
+
+    /// The builder's `client_id` override must reach the token-exchange wire so
+    /// host apps (e.g. the CLI) attribute their token traffic correctly.
+    #[tokio::test]
+    async fn builder_client_id_attributes_token_traffic() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = env_guard();
+        clear_env();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/jwt"))
+            .and(body_string_contains("client_id=hotdata-cli"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "minted-jwt",
+                "expires_in": 300,
+                "refresh_token": "r1"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = Client::builder()
+            .api_token("hd_opaque")
+            .workspace_id("ws_x")
+            .client_id("hotdata-cli")
+            .base_url(server.uri())
+            .build()
+            .expect("build should succeed");
+
+        // Driving the token provider forces a mint; the mock only matches when
+        // the body carries client_id=hotdata-cli, so a None here means the
+        // override did not reach the wire.
+        let bearer = client.configuration().resolve_bearer_token().await;
+        assert_eq!(bearer.as_deref(), Some("minted-jwt"));
+
+        clear_env();
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -393,6 +393,119 @@ impl Client {
         }
     }
 
+    /// Stream an arbitrary byte source to `POST /v1/files`, the raw-body upload
+    /// endpoint.
+    ///
+    /// The generated [`apis::uploads_api::upload_file`] (and the ergonomic
+    /// `uploads().upload`) take a [`std::path::PathBuf`] only — they open a file
+    /// and wrap it in a stream internally. That can't express an arbitrary byte
+    /// source (a network download, an in-memory buffer, a transformed stream),
+    /// which a host app needs to upload from a `--url` fetch or to wrap its
+    /// source in a progress meter. This method closes that gap: it takes any
+    /// `Stream` of `Result<Bytes, _>` and streams it to the same endpoint with
+    /// the same wire format (raw `application/octet-stream` body, the upload ID
+    /// returned in [`models::UploadResponse`]).
+    ///
+    /// The request is built wire-identically to the generated op: same
+    /// `base_path` + `/v1/files` join, same `X-Workspace-Id` / `X-Session-Id`
+    /// scope headers (from `configuration.api_keys`), same bearer auth (via
+    /// [`Configuration::resolve_bearer_token`]), same user-agent. It reuses the
+    /// configured `configuration.client`, so a caller-supplied client (e.g. one
+    /// built with no request timeout via
+    /// [`ClientBuilder::reqwest_client`](crate::ClientBuilder)) applies to the
+    /// transfer.
+    ///
+    /// Progress reporting and timeout policy stay with the caller: wrap the
+    /// source stream to drive a progress bar, and supply a no-timeout client if
+    /// the upload may outlive the default request timeout. This method owns
+    /// neither.
+    ///
+    /// `content_type` sets the `Content-Type` header (e.g. `text/csv`,
+    /// `application/parquet`); pass `None` to default to
+    /// `application/octet-stream`. The endpoint accepts the raw bytes as-is.
+    pub async fn upload_stream<S, B, E>(
+        &self,
+        body: S,
+        content_type: Option<&str>,
+    ) -> Result<models::UploadResponse, Error<apis::uploads_api::UploadFileError>>
+    where
+        S: futures_core::Stream<Item = Result<B, E>> + Send + 'static,
+        bytes::Bytes: From<B>,
+        B: 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
+    {
+        use crate::apis::ResponseContent;
+        use serde::de::Error as _;
+
+        let configuration = &self.configuration;
+
+        let uri_str = format!("{}/v1/files", configuration.base_path);
+        let mut req_builder = configuration
+            .client
+            .request(reqwest::Method::POST, &uri_str);
+
+        if let Some(ref user_agent) = configuration.user_agent {
+            req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+        }
+        req_builder = req_builder.header(
+            reqwest::header::CONTENT_TYPE,
+            content_type.unwrap_or("application/octet-stream"),
+        );
+        if let Some(apikey) = configuration.api_keys.get("X-Workspace-Id") {
+            let key = apikey.key.clone();
+            let value = match apikey.prefix {
+                Some(ref prefix) => format!("{} {}", prefix, key),
+                None => key,
+            };
+            req_builder = req_builder.header("X-Workspace-Id", value);
+        };
+        if let Some(apikey) = configuration.api_keys.get("X-Session-Id") {
+            let key = apikey.key.clone();
+            let value = match apikey.prefix {
+                Some(ref prefix) => format!("{} {}", prefix, key),
+                None => key,
+            };
+            req_builder = req_builder.header("X-Session-Id", value);
+        };
+        if let Some(token) = configuration.resolve_bearer_token().await {
+            req_builder = req_builder.bearer_auth(token);
+        };
+        req_builder = req_builder.body(reqwest::Body::wrap_stream(body));
+
+        let req = req_builder.build()?;
+        let resp = configuration.client.execute(req).await?;
+
+        let status = resp.status();
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream")
+            .to_owned();
+        let is_json =
+            content_type.starts_with("application") && content_type.contains("json");
+
+        if !status.is_client_error() && !status.is_server_error() {
+            let content = resp.text().await?;
+            if is_json {
+                serde_json::from_str(&content).map_err(Error::from)
+            } else {
+                Err(Error::from(serde_json::Error::custom(format!(
+                    "Received `{content_type}` content type response that cannot be converted to `models::UploadResponse`"
+                ))))
+            }
+        } else {
+            let content = resp.text().await?;
+            let entity: Option<apis::uploads_api::UploadFileError> =
+                serde_json::from_str(&content).ok();
+            Err(Error::ResponseError(ResponseContent {
+                status,
+                content,
+                entity,
+            }))
+        }
+    }
+
     /// List recent query runs.
     pub async fn list_query_runs(
         &self,
@@ -1026,6 +1139,121 @@ mod tests {
             .expect("submit_query should succeed with scoped headers");
 
         assert!(matches!(outcome, QueryOutcome::Submitted(_)));
+    }
+
+    /// A streamed body POSTs to `/v1/files`, parses the `201 UploadResponse`,
+    /// and the streamed bytes arrive intact.
+    #[tokio::test]
+    async fn upload_stream_posts_and_parses_response() {
+        use wiremock::matchers::{body_bytes, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = env_guard();
+        clear_env();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .and(body_bytes(b"hello world".to_vec()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "content_type": "text/csv",
+                "created_at": "2026-06-04T00:00:00Z",
+                "id": "upload_abc",
+                "size_bytes": 11,
+                "status": "ready",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = query_test_client(&server.uri());
+        // Two chunks so the body is genuinely streamed (not a single buffer).
+        let chunks: Vec<Result<bytes::Bytes, std::io::Error>> = vec![
+            Ok(bytes::Bytes::from_static(b"hello ")),
+            Ok(bytes::Bytes::from_static(b"world")),
+        ];
+        let stream = futures::stream::iter(chunks);
+
+        let resp = client
+            .upload_stream(stream, Some("text/csv"))
+            .await
+            .expect("upload_stream should succeed");
+
+        assert_eq!(resp.id, "upload_abc");
+        assert_eq!(resp.size_bytes, 11);
+        assert_eq!(resp.status, "ready");
+    }
+
+    /// The request carries `X-Workspace-Id`, `Authorization: Bearer`, and the
+    /// `Content-Type` — wire-identical to the generated `upload_file` op.
+    #[tokio::test]
+    async fn upload_stream_sends_scope_auth_and_content_type() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = env_guard();
+        clear_env();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .and(header("X-Workspace-Id", "ws_test"))
+            .and(header("Authorization", "Bearer test-bearer"))
+            .and(header("Content-Type", "application/parquet"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "created_at": "2026-06-04T00:00:00Z",
+                "id": "upload_scoped",
+                "size_bytes": 3,
+                "status": "ready",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = query_test_client(&server.uri());
+        // The mock only matches when all three headers are present, so a
+        // successful parse proves they reached the wire.
+        let stream = futures::stream::once(async {
+            Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"abc"))
+        });
+
+        let resp = client
+            .upload_stream(stream, Some("application/parquet"))
+            .await
+            .expect("upload_stream should succeed with scoped headers");
+
+        assert_eq!(resp.id, "upload_scoped");
+    }
+
+    /// With no `content_type`, the request defaults to
+    /// `application/octet-stream`.
+    #[tokio::test]
+    async fn upload_stream_defaults_content_type() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = env_guard();
+        clear_env();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .and(header("Content-Type", "application/octet-stream"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "created_at": "2026-06-04T00:00:00Z",
+                "id": "upload_default",
+                "size_bytes": 1,
+                "status": "ready",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = query_test_client(&server.uri());
+        let stream = futures::stream::once(async {
+            Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"x"))
+        });
+
+        let resp = client
+            .upload_stream(stream, None)
+            .await
+            .expect("upload_stream should default content-type");
+
+        assert_eq!(resp.id, "upload_default");
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1185,8 +1185,9 @@ mod tests {
         assert_eq!(resp.status, "ready");
     }
 
-    /// The request carries `X-Workspace-Id`, `Authorization: Bearer`, and the
-    /// `Content-Type` — wire-identical to the generated `upload_file` op.
+    /// The request carries `X-Workspace-Id` and `Authorization: Bearer` like the
+    /// generated `upload_file` op, plus the intentional `Content-Type` header
+    /// `upload_file` omits.
     #[tokio::test]
     async fn upload_stream_sends_scope_auth_and_content_type() {
         use wiremock::matchers::{header, method, path};

--- a/src/client.rs
+++ b/src/client.rs
@@ -833,8 +833,9 @@ mod tests {
     /// Serialize env-mutating tests so they don't race each other. `std::env`
     /// is process-global, so concurrent test threads would otherwise interfere.
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        // Shared crate-wide lock (see crate::ENV_LOCK) so these env-mutating
+        // tests serialize against auth.rs's env tests too — env is global.
+        crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     fn clear_env() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -406,11 +406,14 @@ impl Client {
     /// the same wire format (raw `application/octet-stream` body, the upload ID
     /// returned in [`models::UploadResponse`]).
     ///
-    /// The request is built wire-identically to the generated op: same
-    /// `base_path` + `/v1/files` join, same `X-Workspace-Id` / `X-Session-Id`
-    /// scope headers (from `configuration.api_keys`), same bearer auth (via
-    /// [`Configuration::resolve_bearer_token`]), same user-agent. It reuses the
-    /// configured `configuration.client`, so a caller-supplied client (e.g. one
+    /// The request mirrors the generated op: same `base_path` + `/v1/files`
+    /// join, same `X-Workspace-Id` scope header (from `configuration.api_keys`),
+    /// same bearer auth (via [`Configuration::resolve_bearer_token`]), same
+    /// user-agent. It additionally sends the `X-Session-Id` scope header and an
+    /// explicit `Content-Type` (see `content_type` below) — neither of which the
+    /// generated `upload_file` sets — so a session-scoped, typed upload is
+    /// expressible. It reuses the configured `configuration.client`, so a
+    /// caller-supplied client (e.g. one
     /// built with no request timeout via
     /// [`ClientBuilder::reqwest_client`](crate::ClientBuilder)) applies to the
     /// transfer.

--- a/src/client.rs
+++ b/src/client.rs
@@ -301,6 +301,98 @@ impl Client {
         apis::query_api::query(&self.configuration, request, None).await
     }
 
+    /// Submit a query to `POST /v1/query`, surfacing BOTH response shapes the
+    /// server can return.
+    ///
+    /// The generated [`apis::query_api::query`](crate::apis::query_api::query)
+    /// op only models the `200 QueryResponse` branch — the generator collapsed
+    /// the `202 AsyncQueryResponse` branch, so callers can't recover the
+    /// `query_run_id` when a query goes async. This method closes that gap:
+    ///
+    /// - HTTP `200` decodes the inline [`models::QueryResponse`] into
+    ///   [`QueryOutcome::Inline`].
+    /// - HTTP `202` decodes the [`models::AsyncQueryResponse`] (carrying
+    ///   `query_run_id` / `status` / `status_url`) into
+    ///   [`QueryOutcome::Submitted`]; poll it via
+    ///   [`Client::list_query_runs`] / the query-runs API.
+    /// - Any other status maps to the SDK's existing
+    ///   [`Error::ResponseError`](crate::apis::Error) /
+    ///   [`ResponseContent`](crate::apis::ResponseContent) shape with a
+    ///   [`apis::query_api::QueryError`] entity, identical to the generated op.
+    ///
+    /// `database_id` selects the database via the `X-Database-Id` header (the
+    /// spec lets database scope come from that header OR the `database_id` body
+    /// field; pass `None` to use the body field or rely on the default). The
+    /// request is built wire-identically to the generated op (same workspace /
+    /// session scope headers, same bearer auth, same `base_path`/`/v1` join,
+    /// same JSON body) plus the `202` handling.
+    pub async fn submit_query(
+        &self,
+        request: models::QueryRequest,
+        database_id: Option<&str>,
+    ) -> Result<QueryOutcome, Error<apis::query_api::QueryError>> {
+        use crate::apis::ResponseContent;
+
+        let configuration = &self.configuration;
+
+        let uri_str = format!("{}/v1/query", configuration.base_path);
+        let mut req_builder = configuration
+            .client
+            .request(reqwest::Method::POST, &uri_str);
+
+        if let Some(ref user_agent) = configuration.user_agent {
+            req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+        }
+        if let Some(param_value) = database_id {
+            req_builder = req_builder.header("X-Database-Id", param_value.to_string());
+        }
+        if let Some(apikey) = configuration.api_keys.get("X-Workspace-Id") {
+            let key = apikey.key.clone();
+            let value = match apikey.prefix {
+                Some(ref prefix) => format!("{} {}", prefix, key),
+                None => key,
+            };
+            req_builder = req_builder.header("X-Workspace-Id", value);
+        };
+        if let Some(apikey) = configuration.api_keys.get("X-Session-Id") {
+            let key = apikey.key.clone();
+            let value = match apikey.prefix {
+                Some(ref prefix) => format!("{} {}", prefix, key),
+                None => key,
+            };
+            req_builder = req_builder.header("X-Session-Id", value);
+        };
+        if let Some(token) = configuration.resolve_bearer_token().await {
+            req_builder = req_builder.bearer_auth(token);
+        };
+        req_builder = req_builder.json(&request);
+
+        let req = req_builder.build()?;
+        let resp = configuration.client.execute(req).await?;
+
+        let status = resp.status();
+
+        if status == reqwest::StatusCode::ACCEPTED {
+            // 202 Accepted: the query was submitted asynchronously.
+            let content = resp.text().await?;
+            let submitted: models::AsyncQueryResponse = serde_json::from_str(&content)?;
+            Ok(QueryOutcome::Submitted(submitted))
+        } else if !status.is_client_error() && !status.is_server_error() {
+            // 2xx (typically 200): inline results.
+            let content = resp.text().await?;
+            let inline: models::QueryResponse = serde_json::from_str(&content)?;
+            Ok(QueryOutcome::Inline(inline))
+        } else {
+            let content = resp.text().await?;
+            let entity: Option<apis::query_api::QueryError> = serde_json::from_str(&content).ok();
+            Err(Error::ResponseError(ResponseContent {
+                status,
+                content,
+                entity,
+            }))
+        }
+    }
+
     /// List recent query runs.
     pub async fn list_query_runs(
         &self,
@@ -577,6 +669,25 @@ impl Client {
     }
 }
 
+/// The two response shapes [`Client::submit_query`] can return.
+///
+/// `POST /v1/query` returns EITHER inline results (`200 QueryResponse`) or an
+/// async-submission acknowledgement (`202 AsyncQueryResponse`) depending on
+/// whether the query ran synchronously. This enum surfaces both so callers can
+/// recover the `query_run_id` and poll when a query goes async.
+///
+/// Marked `#[non_exhaustive]`: new variants may be added without a breaking
+/// change, so downstream `match`es should carry a wildcard arm.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum QueryOutcome {
+    /// The query ran synchronously and rows were returned inline (HTTP 200).
+    Inline(models::QueryResponse),
+    /// The query was submitted asynchronously (HTTP 202); poll its
+    /// `query_run_id` for completion.
+    Submitted(models::AsyncQueryResponse),
+}
+
 /// How long to wait, and how often to poll, when awaiting a result.
 ///
 /// Defaults to a 120-second timeout polled every second. Use
@@ -775,6 +886,145 @@ mod tests {
         assert_eq!(bearer.as_deref(), Some("minted-jwt"));
 
         clear_env();
+    }
+
+    /// Helper: build a client pointed at a wiremock server with a static bearer
+    /// token (no JWT-exchange round-trip), so query tests assert on the
+    /// `/v1/query` request directly.
+    fn query_test_client(base_url: &str) -> Client {
+        let mut configuration = Configuration {
+            base_path: base_url.to_owned(),
+            user_agent: Some("hotdata-rust-test".to_owned()),
+            bearer_access_token: Some("test-bearer".to_owned()),
+            ..Configuration::default()
+        };
+        configuration.api_keys.insert(
+            WORKSPACE_ID_HEADER.to_owned(),
+            ApiKey {
+                prefix: None,
+                key: "ws_test".to_owned(),
+            },
+        );
+        Client::from_configuration(configuration)
+    }
+
+    /// 200 -> inline results decode into `QueryOutcome::Inline`.
+    #[tokio::test]
+    async fn submit_query_200_inline() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = env_guard();
+        clear_env();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "columns": ["n"],
+                "execution_time_ms": 3,
+                "nullable": [false],
+                "query_run_id": "qr_inline",
+                "row_count": 1,
+                "rows": [[1]],
+            })))
+            .mount(&server)
+            .await;
+
+        let client = query_test_client(&server.uri());
+        let outcome = client
+            .submit_query(models::QueryRequest::new("select 1".into()), None)
+            .await
+            .expect("submit_query should succeed");
+
+        match outcome {
+            QueryOutcome::Inline(resp) => {
+                assert_eq!(resp.query_run_id, "qr_inline");
+                assert_eq!(resp.row_count, 1);
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    /// 202 -> async submission decodes into `QueryOutcome::Submitted` with the
+    /// right `query_run_id`.
+    #[tokio::test]
+    async fn submit_query_202_submitted() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = env_guard();
+        clear_env();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/query"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "query_run_id": "qr_async_42",
+                "status": "pending",
+                "status_url": "https://api.hotdata.dev/v1/query-runs/qr_async_42",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = query_test_client(&server.uri());
+        let outcome = client
+            .submit_query(
+                models::QueryRequest {
+                    r#async: Some(true),
+                    ..models::QueryRequest::new("select 1".into())
+                },
+                None,
+            )
+            .await
+            .expect("submit_query should succeed");
+
+        match outcome {
+            QueryOutcome::Submitted(resp) => {
+                assert_eq!(resp.query_run_id, "qr_async_42");
+                assert_eq!(resp.status, "pending");
+                assert_eq!(
+                    resp.status_url,
+                    "https://api.hotdata.dev/v1/query-runs/qr_async_42"
+                );
+            }
+            other => panic!("expected Submitted, got {other:?}"),
+        }
+    }
+
+    /// The request carries `X-Database-Id` (when passed), `X-Workspace-Id`
+    /// (api_keys), and the bearer token — wire-identical to the generated op.
+    #[tokio::test]
+    async fn submit_query_sends_scope_and_auth_headers() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let _g = env_guard();
+        clear_env();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/query"))
+            .and(header("X-Database-Id", "db_123"))
+            .and(header("X-Workspace-Id", "ws_test"))
+            .and(header("Authorization", "Bearer test-bearer"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "query_run_id": "qr_scoped",
+                "status": "pending",
+                "status_url": "https://api.hotdata.dev/v1/query-runs/qr_scoped",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = query_test_client(&server.uri());
+        // The mock only matches when all three headers are present, so a
+        // successful Submitted outcome proves they reached the wire.
+        let outcome = client
+            .submit_query(
+                models::QueryRequest::new("select 1".into()),
+                Some("db_123"),
+            )
+            .await
+            .expect("submit_query should succeed with scoped headers");
+
+        assert!(matches!(outcome, QueryOutcome::Submitted(_)));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,9 @@ pub use arrow::{
 pub use auth::{BearerTokenProvider, TokenExchangeError, TokenManager};
 #[cfg(feature = "arrow")]
 pub use client::QueryToArrowError;
-pub use client::{AwaitResultError, Client, ClientBuilder, ClientError, PollConfig};
+pub use client::{
+    AwaitResultError, Client, ClientBuilder, ClientError, PollConfig, QueryOutcome,
+};
 pub use resources::{
     ConnectionTypesApi, ConnectionsApi, DatabaseContextApi, DatabasesApi, DatasetsApi,
     EmbeddingProvidersApi, IndexesApi, InformationSchemaApi, JobsApi, QueryApi, QueryRunsApi,
@@ -47,7 +49,7 @@ pub mod prelude {
     pub use crate::apis::configuration::Configuration;
     #[cfg(feature = "arrow")]
     pub use crate::arrow::{ArrowError, ArrowResult};
-    pub use crate::client::{Client, ClientBuilder, PollConfig};
+    pub use crate::client::{Client, ClientBuilder, PollConfig, QueryOutcome};
     pub use crate::field;
     pub use crate::models::*;
     pub use crate::resources::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,12 @@ pub use resources::{
 };
 pub use status::{QueryRunStatus, QueryRunStatusExt, ResultStatus, ResultStatusExt};
 
+/// Process-wide lock serializing every test that mutates `std::env`. Env is a
+/// process-global resource, so per-module locks would race; all env-mutating
+/// tests across the crate (auth.rs, client.rs, …) lock this single mutex.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub mod prelude {
     pub use crate::apis::configuration::Configuration;
     #[cfg(feature = "arrow")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ pub use arrow::{
     get_result_arrow, stream_result_arrow, ArrowBatchStream, ArrowError, ArrowResult,
     ARROW_STREAM_MEDIA_TYPE,
 };
-pub use auth::{BearerTokenProvider, TokenExchangeError, TokenManager};
+pub use auth::{
+    BearerTokenProvider, PersistCallback, TokenExchangeError, TokenManager, TokenManagerOptions,
+};
 #[cfg(feature = "arrow")]
 pub use client::QueryToArrowError;
 pub use client::{


### PR DESCRIPTION
Adds the SDK surface the hotdata-cli refactor needs: configurable token-exchange `client_id` (`TokenManagerOptions` + `ClientBuilder::client_id`), an async-aware `submit_query` that surfaces the 202 query-run response the generated op drops, and `upload_stream` for arbitrary streaming uploads. Also unifies test env-locking across modules to remove a flaky race.