### PR TITLE
feat: redacted request/response debug logging

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -86,7 +86,7 @@ jobs:
           fail=0
 
           # 1. Hand-written, regen-immune modules must exist.
-          for f in src/lib.rs src/auth.rs src/arrow.rs src/client.rs src/resources.rs src/field.rs src/status.rs; do
+          for f in src/lib.rs src/auth.rs src/arrow.rs src/client.rs src/resources.rs src/field.rs src/status.rs src/http_log.rs; do
             if [ ! -f "$f" ]; then
               echo "::error::$f is missing (regen clobbered the ergonomic layer)"
               fail=1
@@ -94,7 +94,7 @@ jobs:
           done
 
           # 2. lib.rs must still wire the hand-written modules.
-          for decl in 'pub mod auth;' 'pub mod client;' 'pub mod arrow;' 'pub mod resources;' 'pub mod field;' 'pub mod status;'; do
+          for decl in 'pub mod auth;' 'pub mod client;' 'pub mod arrow;' 'pub mod resources;' 'pub mod field;' 'pub mod status;' 'pub mod http_log;'; do
             if ! grep -q "$decl" src/lib.rs; then
               echo "::error::src/lib.rs no longer declares '$decl'"
               fail=1
@@ -123,11 +123,23 @@ jobs:
             fail=1
           fi
 
+          # 5. The request/response debug-logging hooks must have survived the
+          #    generator. api.mustache emits crate::http_log::log_request +
+          #    log_response_status/_body at every op (issue #135).
+          if ! grep -rq 'crate::http_log::log_request' src/apis/; then
+            echo "::error::http_log::log_request missing from generated apis (api.mustache debug-logging hook drift)"
+            fail=1
+          fi
+          if ! grep -rq 'crate::http_log::log_response_status' src/apis/; then
+            echo "::error::http_log::log_response_status missing from generated apis (api.mustache debug-logging hook drift)"
+            fail=1
+          fi
+
           if [ "$fail" -ne 0 ]; then
-            echo "::error::Regen-safety check failed: the ergonomic layer or auth hooks did not survive regeneration."
+            echo "::error::Regen-safety check failed: the ergonomic layer or auth/logging hooks did not survive regeneration."
             exit 1
           fi
-          echo "Ergonomic layer survived regeneration: hand-written modules, lib.rs wiring, and JWT/bearer hooks all intact."
+          echo "Ergonomic layer survived regeneration: hand-written modules, lib.rs wiring, and JWT/bearer + debug-logging hooks all intact."
 
       # cargo check is the template-drift tripwire. --all-features compiles the
       # optional arrow surface too. The --no-run test build catches breakage in

--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -4,6 +4,7 @@ README.md
 Cargo.toml
 src/lib.rs
 src/auth.rs
+src/http_log.rs
 src/arrow.rs
 src/client.rs
 src/resources.rs

--- a/.openapi-generator-templates/README.md
+++ b/.openapi-generator-templates/README.md
@@ -11,6 +11,17 @@ These templates replace that field with `api_keys: HashMap<String, ApiKey>`
 keyed by header name, and change the per-operation header-emission code
 to look up the right scheme: `configuration.api_keys.get("X-Workspace-Id")`.
 
+## Debug-logging hook (`api.mustache`)
+
+Every generated op emits `crate::http_log::log_request(&req)` after building
+the request, `crate::http_log::log_response_status(status)` after reading the
+status, and `crate::http_log::log_response_body(&content)` at each response
+body read. These call into the hand-written, regen-immune `src/http_log.rs`
+module, which masks credentials and emits `log::debug!` records on the
+`hotdata::http` target (issue #135). Keeping the calls in the template means
+they re-appear on every regeneration; the regen-safety CI guard greps the
+generated `src/apis` for them and fails if a generator change drops them.
+
 ## Why live here instead of upstream
 
 Upstream PR [#19511](https://github.com/OpenAPITools/openapi-generator/pull/19511)

--- a/.openapi-generator-templates/reqwest/api.mustache
+++ b/.openapi-generator-templates/reqwest/api.mustache
@@ -585,9 +585,11 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{/hasBodyParam}}
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req){{#supportAsync}}.await{{/supportAsync}}?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     {{^supportMultipleResponses}}
     {{^isResponseFile}}
     {{#returnType}}
@@ -612,6 +614,7 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
         {{/returnType}}
         {{#returnType}}
         let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             {{^useSerdePathToError}}
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
@@ -636,12 +639,14 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
         {{/isResponseFile}}
         {{^isResponseFile}}
         let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&content).ok();
         Ok(ResponseContent { status, content, entity })
         {{/isResponseFile}}
         {{/supportMultipleResponses}}
     } else {
         let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent { status, content, entity }))
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `arrow` feature: `get_result_arrow` / `stream_result_arrow` decode Apache Arrow IPC result streams into `RecordBatch`es, surface the `X-Total-Row-Count` and `rel="next"` Link headers, and map the `202`/`409`/`404`/`400` result states to typed `ArrowError` variants.
 - Flat re-export surface (`hotdata::Client`, `hotdata::Configuration`, `hotdata::prelude::*`) alongside the namespaced `hotdata::apis` / `hotdata::models`. The prelude also re-exports the resource handles, `PollConfig`, the `field` helpers, and (with the `arrow` feature) `ArrowError`.
 - The SDK's own error enums (`ClientError`, `TokenExchangeError`, `ArrowError`, `AwaitResultError`, `QueryToArrowError`) are `#[non_exhaustive]`, so new variants can be added without a breaking change — match them with a wildcard arm.
+- Request/response debug logging (`hotdata::http_log`) covering every HTTP call — generated ops plus the hand-written `submit_query` / `upload_stream` / Arrow fetch / JWT mint. Each emits `log::debug!` records on the `hotdata::http` target (`>>> METHOD url`, headers, body; `<<< status`, body) so a host (e.g. the CLI's `--debug`) can render them with any `log` backend. `Authorization` bearer tokens and sensitive JSON/form fields (`api_token`, `secret`, `password`, …) are masked before logging; the SDK installs no logger and stays silent without a backend. The `api.mustache` template emits the hooks so they survive regeneration, and the regen-safety CI guard verifies they remain.
 
 ### Changed
 
-- Regeneration is now safe for the hand-written ergonomic layer: the generator only overwrites generated subtrees (`src/apis`, `src/models`, `docs`) and skips `src/lib.rs`, `src/auth.rs`, `src/arrow.rs`, `src/client.rs`, `src/resources.rs`, `src/field.rs`, and `Cargo.toml` via `.openapi-generator-ignore`. The regen-safety CI guard verifies all of these survive and stay wired into `lib.rs`.
+- Regeneration is now safe for the hand-written ergonomic layer: the generator only overwrites generated subtrees (`src/apis`, `src/models`, `docs`) and skips `src/lib.rs`, `src/auth.rs`, `src/http_log.rs`, `src/arrow.rs`, `src/client.rs`, `src/resources.rs`, `src/field.rs`, and `Cargo.toml` via `.openapi-generator-ignore`. The regen-safety CI guard verifies all of these survive and stay wired into `lib.rs`.
 
 ## [0.1.0]
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,31 @@ let arrow = client
     .await?;
 ```
 
+## Debug logging
+
+Every HTTP call the SDK makes — generated operations and the hand-written `submit_query`, `upload_stream`, Arrow fetch, and JWT mint — emits `log::debug!` records on the `hotdata::http` target: the request (`>>> METHOD url`, headers, body) and the response (`<<< status`, body). `Authorization` bearer tokens and sensitive body fields (`api_token`, `secret`, `password`, …) are masked before logging.
+
+The SDK installs no logger and prints nothing on its own. To see the records, wire any [`log`](https://docs.rs/log) backend and enable the `hotdata::http` target at debug level. For example with [`env_logger`](https://docs.rs/env_logger):
+
+```rust
+// RUST_LOG=hotdata::http=debug cargo run
+env_logger::init();
+```
+
+```toml
+[dependencies]
+env_logger = "0.11"
+```
+
+```text
+>>> POST https://api.hotdata.dev/v1/query
+  authorization: Bearer hd_a...cdef
+  content-type: application/json
+{"sql":"SELECT 1"}
+<<< 200 OK
+{"result_id":"…","columns":[…]}
+```
+
 ## API reference
 
 Generated documentation builds on [docs.rs](https://docs.rs/hotdata) (with `all-features` enabled, so the `arrow` surface is included).

--- a/src/apis/connection_types_api.rs
+++ b/src/apis/connection_types_api.rs
@@ -59,9 +59,11 @@ pub async fn get_connection_type(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -71,6 +73,7 @@ pub async fn get_connection_type(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ConnectionTypeDetail`"))),
@@ -78,6 +81,7 @@ pub async fn get_connection_type(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetConnectionTypeError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -110,9 +114,11 @@ pub async fn list_connection_types(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -122,6 +128,7 @@ pub async fn list_connection_types(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListConnectionTypesResponse`"))),
@@ -129,6 +136,7 @@ pub async fn list_connection_types(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListConnectionTypesError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/connections_api.rs
+++ b/src/apis/connections_api.rs
@@ -130,9 +130,11 @@ pub async fn check_connection_health(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -142,6 +144,7 @@ pub async fn check_connection_health(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ConnectionHealthResponse`"))),
@@ -149,6 +152,7 @@ pub async fn check_connection_health(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CheckConnectionHealthError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -188,9 +192,11 @@ pub async fn create_connection(
     req_builder = req_builder.json(&p_body_create_connection_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -200,6 +206,7 @@ pub async fn create_connection(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::CreateConnectionResponse`"))),
@@ -207,6 +214,7 @@ pub async fn create_connection(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateConnectionError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -249,14 +257,17 @@ pub async fn delete_connection(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteConnectionError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -305,14 +316,17 @@ pub async fn delete_managed_table(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteManagedTableError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -353,9 +367,11 @@ pub async fn get_connection(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -365,6 +381,7 @@ pub async fn get_connection(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::GetConnectionResponse`"))),
@@ -372,6 +389,7 @@ pub async fn get_connection(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetConnectionError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -418,9 +436,11 @@ pub async fn get_table_profile(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -430,6 +450,7 @@ pub async fn get_table_profile(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::TableProfileResponse`"))),
@@ -437,6 +458,7 @@ pub async fn get_table_profile(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetTableProfileError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -469,9 +491,11 @@ pub async fn list_connections(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -481,6 +505,7 @@ pub async fn list_connections(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListConnectionsResponse`"))),
@@ -488,6 +513,7 @@ pub async fn list_connections(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListConnectionsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -539,9 +565,11 @@ pub async fn load_managed_table(
     req_builder = req_builder.json(&p_body_load_managed_table_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -551,6 +579,7 @@ pub async fn load_managed_table(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::LoadManagedTableResponse`"))),
@@ -558,6 +587,7 @@ pub async fn load_managed_table(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<LoadManagedTableError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -600,14 +630,17 @@ pub async fn purge_connection_cache(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<PurgeConnectionCacheError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -656,14 +689,17 @@ pub async fn purge_table_cache(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<PurgeTableCacheError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/database_context_api.rs
+++ b/src/apis/database_context_api.rs
@@ -84,14 +84,17 @@ pub async fn delete_database_context(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteDatabaseContextError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -134,9 +137,11 @@ pub async fn get_database_context(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -146,6 +151,7 @@ pub async fn get_database_context(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::GetDatabaseContextResponse`"))),
@@ -153,6 +159,7 @@ pub async fn get_database_context(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetDatabaseContextError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -192,9 +199,11 @@ pub async fn list_database_contexts(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -204,6 +213,7 @@ pub async fn list_database_contexts(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListDatabaseContextsResponse`"))),
@@ -211,6 +221,7 @@ pub async fn list_database_contexts(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListDatabaseContextsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -256,9 +267,11 @@ pub async fn upsert_database_context(
     req_builder = req_builder.json(&p_body_upsert_database_context_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -268,6 +281,7 @@ pub async fn upsert_database_context(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::UpsertDatabaseContextResponse`"))),
@@ -275,6 +289,7 @@ pub async fn upsert_database_context(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<UpsertDatabaseContextError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/databases_api.rs
+++ b/src/apis/databases_api.rs
@@ -100,14 +100,17 @@ pub async fn attach_database_catalog(
     req_builder = req_builder.json(&p_body_attach_database_catalog_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<AttachDatabaseCatalogError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -147,9 +150,11 @@ pub async fn create_database(
     req_builder = req_builder.json(&p_body_create_database_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -159,6 +164,7 @@ pub async fn create_database(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::CreateDatabaseResponse`"))),
@@ -166,6 +172,7 @@ pub async fn create_database(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateDatabaseError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -208,14 +215,17 @@ pub async fn delete_database(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteDatabaseError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -260,14 +270,17 @@ pub async fn detach_database_catalog(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DetachDatabaseCatalogError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -308,9 +321,11 @@ pub async fn get_database(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -320,6 +335,7 @@ pub async fn get_database(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::DatabaseDetailResponse`"))),
@@ -327,6 +343,7 @@ pub async fn get_database(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetDatabaseError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -358,9 +375,11 @@ pub async fn list_databases(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -370,6 +389,7 @@ pub async fn list_databases(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListDatabasesResponse`"))),
@@ -377,6 +397,7 @@ pub async fn list_databases(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListDatabasesError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/datasets_api.rs
+++ b/src/apis/datasets_api.rs
@@ -106,9 +106,11 @@ pub async fn create_dataset(
     req_builder = req_builder.json(&p_body_create_dataset_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -118,6 +120,7 @@ pub async fn create_dataset(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::CreateDatasetResponse`"))),
@@ -125,6 +128,7 @@ pub async fn create_dataset(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateDatasetError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -174,14 +178,17 @@ pub async fn delete_dataset(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteDatasetError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -221,9 +228,11 @@ pub async fn get_dataset(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -233,6 +242,7 @@ pub async fn get_dataset(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::GetDatasetResponse`"))),
@@ -240,6 +250,7 @@ pub async fn get_dataset(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetDatasetError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -289,9 +300,11 @@ pub async fn list_dataset_versions(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -301,6 +314,7 @@ pub async fn list_dataset_versions(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListDatasetVersionsResponse`"))),
@@ -308,6 +322,7 @@ pub async fn list_dataset_versions(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListDatasetVersionsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -359,9 +374,11 @@ pub async fn list_datasets(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -371,6 +388,7 @@ pub async fn list_datasets(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListDatasetsResponse`"))),
@@ -378,6 +396,7 @@ pub async fn list_datasets(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListDatasetsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -428,9 +447,11 @@ pub async fn update_dataset(
     req_builder = req_builder.json(&p_body_update_dataset_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -440,6 +461,7 @@ pub async fn update_dataset(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::UpdateDatasetResponse`"))),
@@ -447,6 +469,7 @@ pub async fn update_dataset(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<UpdateDatasetError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/embedding_providers_api.rs
+++ b/src/apis/embedding_providers_api.rs
@@ -83,9 +83,11 @@ pub async fn create_embedding_provider(
     req_builder = req_builder.json(&p_body_create_embedding_provider_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -95,6 +97,7 @@ pub async fn create_embedding_provider(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::CreateEmbeddingProviderResponse`"))),
@@ -102,6 +105,7 @@ pub async fn create_embedding_provider(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateEmbeddingProviderError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -143,14 +147,17 @@ pub async fn delete_embedding_provider(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteEmbeddingProviderError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -190,9 +197,11 @@ pub async fn get_embedding_provider(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -202,6 +211,7 @@ pub async fn get_embedding_provider(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::EmbeddingProviderResponse`"))),
@@ -209,6 +219,7 @@ pub async fn get_embedding_provider(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetEmbeddingProviderError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -241,9 +252,11 @@ pub async fn list_embedding_providers(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -253,6 +266,7 @@ pub async fn list_embedding_providers(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListEmbeddingProvidersResponse`"))),
@@ -260,6 +274,7 @@ pub async fn list_embedding_providers(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListEmbeddingProvidersError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -302,9 +317,11 @@ pub async fn update_embedding_provider(
     req_builder = req_builder.json(&p_body_update_embedding_provider_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -314,6 +331,7 @@ pub async fn update_embedding_provider(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::UpdateEmbeddingProviderResponse`"))),
@@ -321,6 +339,7 @@ pub async fn update_embedding_provider(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<UpdateEmbeddingProviderError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/indexes_api.rs
+++ b/src/apis/indexes_api.rs
@@ -111,9 +111,11 @@ pub async fn create_dataset_index(
     req_builder = req_builder.json(&p_body_create_index_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -123,6 +125,7 @@ pub async fn create_dataset_index(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::IndexInfoResponse`"))),
@@ -130,6 +133,7 @@ pub async fn create_dataset_index(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateDatasetIndexError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -181,9 +185,11 @@ pub async fn create_index(
     req_builder = req_builder.json(&p_body_create_index_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -193,6 +199,7 @@ pub async fn create_index(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::IndexInfoResponse`"))),
@@ -200,6 +207,7 @@ pub async fn create_index(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateIndexError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -253,14 +261,17 @@ pub async fn delete_dataset_index(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteDatasetIndexError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -312,14 +323,17 @@ pub async fn delete_index(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteIndexError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -368,9 +382,11 @@ pub async fn list_dataset_indexes(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -380,6 +396,7 @@ pub async fn list_dataset_indexes(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListIndexesResponse`"))),
@@ -387,6 +404,7 @@ pub async fn list_dataset_indexes(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListDatasetIndexesError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -433,9 +451,11 @@ pub async fn list_indexes(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -445,6 +465,7 @@ pub async fn list_indexes(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListIndexesResponse`"))),
@@ -452,6 +473,7 @@ pub async fn list_indexes(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListIndexesError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/information_schema_api.rs
+++ b/src/apis/information_schema_api.rs
@@ -76,9 +76,11 @@ pub async fn information_schema(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -88,6 +90,7 @@ pub async fn information_schema(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::InformationSchemaResponse`"))),
@@ -95,6 +98,7 @@ pub async fn information_schema(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<InformationSchemaError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/jobs_api.rs
+++ b/src/apis/jobs_api.rs
@@ -59,9 +59,11 @@ pub async fn get_job(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -71,6 +73,7 @@ pub async fn get_job(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::JobStatusResponse`"))),
@@ -78,6 +81,7 @@ pub async fn get_job(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetJobError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -132,9 +136,11 @@ pub async fn list_jobs(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -144,6 +150,7 @@ pub async fn list_jobs(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListJobsResponse`"))),
@@ -151,6 +158,7 @@ pub async fn list_jobs(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListJobsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/query_api.rs
+++ b/src/apis/query_api.rs
@@ -66,9 +66,11 @@ pub async fn query(
     req_builder = req_builder.json(&p_body_query_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -78,6 +80,7 @@ pub async fn query(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::QueryResponse`"))),
@@ -85,6 +88,7 @@ pub async fn query(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<QueryError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/query_runs_api.rs
+++ b/src/apis/query_runs_api.rs
@@ -59,9 +59,11 @@ pub async fn get_query_run(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -71,6 +73,7 @@ pub async fn get_query_run(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::QueryRunInfo`"))),
@@ -78,6 +81,7 @@ pub async fn get_query_run(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetQueryRunError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -131,9 +135,11 @@ pub async fn list_query_runs(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -143,6 +149,7 @@ pub async fn list_query_runs(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListQueryRunsResponse`"))),
@@ -150,6 +157,7 @@ pub async fn list_query_runs(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListQueryRunsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/refresh_api.rs
+++ b/src/apis/refresh_api.rs
@@ -52,9 +52,11 @@ pub async fn refresh(
     req_builder = req_builder.json(&p_body_refresh_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -64,6 +66,7 @@ pub async fn refresh(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::RefreshResponse`"))),
@@ -71,6 +74,7 @@ pub async fn refresh(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<RefreshError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/results_api.rs
+++ b/src/apis/results_api.rs
@@ -84,9 +84,11 @@ pub async fn get_result(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -96,6 +98,7 @@ pub async fn get_result(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::GetResultResponse`"))),
@@ -103,6 +106,7 @@ pub async fn get_result(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetResultError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -154,9 +158,11 @@ pub async fn list_results(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -166,6 +172,7 @@ pub async fn list_results(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListResultsResponse`"))),
@@ -173,6 +180,7 @@ pub async fn list_results(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListResultsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/sandboxes_api.rs
+++ b/src/apis/sandboxes_api.rs
@@ -96,9 +96,11 @@ pub async fn create_sandbox(
     req_builder = req_builder.json(&p_body_create_sandbox_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -108,6 +110,7 @@ pub async fn create_sandbox(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::SandboxResponse`"))),
@@ -115,6 +118,7 @@ pub async fn create_sandbox(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateSandboxError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -156,9 +160,11 @@ pub async fn delete_sandbox(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -168,6 +174,7 @@ pub async fn delete_sandbox(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::DeleteSandboxResponse`"))),
@@ -175,6 +182,7 @@ pub async fn delete_sandbox(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteSandboxError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -214,9 +222,11 @@ pub async fn get_sandbox(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -226,6 +236,7 @@ pub async fn get_sandbox(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::SandboxResponse`"))),
@@ -233,6 +244,7 @@ pub async fn get_sandbox(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetSandboxError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -265,9 +277,11 @@ pub async fn list_sandboxes(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -277,6 +291,7 @@ pub async fn list_sandboxes(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListSandboxesResponse`"))),
@@ -284,6 +299,7 @@ pub async fn list_sandboxes(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListSandboxesError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -329,9 +345,11 @@ pub async fn update_sandbox(
     req_builder = req_builder.json(&p_body_update_sandbox_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -341,6 +359,7 @@ pub async fn update_sandbox(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::SandboxResponse`"))),
@@ -348,6 +367,7 @@ pub async fn update_sandbox(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<UpdateSandboxError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/saved_queries_api.rs
+++ b/src/apis/saved_queries_api.rs
@@ -100,9 +100,11 @@ pub async fn create_saved_query(
     req_builder = req_builder.json(&p_body_create_saved_query_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -112,6 +114,7 @@ pub async fn create_saved_query(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::SavedQueryDetail`"))),
@@ -119,6 +122,7 @@ pub async fn create_saved_query(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateSavedQueryError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -160,14 +164,17 @@ pub async fn delete_saved_query(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteSavedQueryError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -216,9 +223,11 @@ pub async fn execute_saved_query(
     req_builder = req_builder.json(&p_body_execute_saved_query_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -228,6 +237,7 @@ pub async fn execute_saved_query(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::QueryResponse`"))),
@@ -235,6 +245,7 @@ pub async fn execute_saved_query(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ExecuteSavedQueryError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -274,9 +285,11 @@ pub async fn get_saved_query(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -286,6 +299,7 @@ pub async fn get_saved_query(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::SavedQueryDetail`"))),
@@ -293,6 +307,7 @@ pub async fn get_saved_query(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetSavedQueryError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -336,9 +351,11 @@ pub async fn list_saved_queries(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -348,6 +365,7 @@ pub async fn list_saved_queries(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListSavedQueriesResponse`"))),
@@ -355,6 +373,7 @@ pub async fn list_saved_queries(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListSavedQueriesError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -404,9 +423,11 @@ pub async fn list_saved_query_versions(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -416,6 +437,7 @@ pub async fn list_saved_query_versions(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListSavedQueryVersionsResponse`"))),
@@ -423,6 +445,7 @@ pub async fn list_saved_query_versions(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListSavedQueryVersionsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -466,9 +489,11 @@ pub async fn update_saved_query(
     req_builder = req_builder.json(&p_body_update_saved_query_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -478,6 +503,7 @@ pub async fn update_saved_query(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::SavedQueryDetail`"))),
@@ -485,6 +511,7 @@ pub async fn update_saved_query(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<UpdateSavedQueryError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/secrets_api.rs
+++ b/src/apis/secrets_api.rs
@@ -82,9 +82,11 @@ pub async fn create_secret(
     req_builder = req_builder.json(&p_body_create_secret_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -94,6 +96,7 @@ pub async fn create_secret(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::CreateSecretResponse`"))),
@@ -101,6 +104,7 @@ pub async fn create_secret(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateSecretError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -142,14 +146,17 @@ pub async fn delete_secret(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteSecretError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -190,9 +197,11 @@ pub async fn get_secret(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -202,6 +211,7 @@ pub async fn get_secret(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::GetSecretResponse`"))),
@@ -209,6 +219,7 @@ pub async fn get_secret(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<GetSecretError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -241,9 +252,11 @@ pub async fn list_secrets(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -253,6 +266,7 @@ pub async fn list_secrets(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListSecretsResponse`"))),
@@ -260,6 +274,7 @@ pub async fn list_secrets(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListSecretsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -302,9 +317,11 @@ pub async fn update_secret(
     req_builder = req_builder.json(&p_body_update_secret_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -314,6 +331,7 @@ pub async fn update_secret(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::UpdateSecretResponse`"))),
@@ -321,6 +339,7 @@ pub async fn update_secret(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<UpdateSecretError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/uploads_api.rs
+++ b/src/apis/uploads_api.rs
@@ -59,9 +59,11 @@ pub async fn list_uploads(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -71,6 +73,7 @@ pub async fn list_uploads(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListUploadsResponse`"))),
@@ -78,6 +81,7 @@ pub async fn list_uploads(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListUploadsError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -119,9 +123,11 @@ pub async fn upload_file(
     req_builder = req_builder.body(reqwest::Body::wrap_stream(stream));
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -131,6 +137,7 @@ pub async fn upload_file(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::UploadResponse`"))),
@@ -138,6 +145,7 @@ pub async fn upload_file(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<UploadFileError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/apis/workspaces_api.rs
+++ b/src/apis/workspaces_api.rs
@@ -67,9 +67,11 @@ pub async fn create_workspace(
     req_builder = req_builder.json(&p_body_create_workspace_request);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -79,6 +81,7 @@ pub async fn create_workspace(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::CreateWorkspaceResponse`"))),
@@ -86,6 +89,7 @@ pub async fn create_workspace(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<CreateWorkspaceError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -120,14 +124,17 @@ pub async fn delete_workspace(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if !status.is_client_error() && !status.is_server_error() {
         Ok(())
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<DeleteWorkspaceError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,
@@ -159,9 +166,11 @@ pub async fn list_workspaces(
     };
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    crate::http_log::log_response_status(status);
     let content_type = resp
         .headers()
         .get("content-type")
@@ -171,6 +180,7 @@ pub async fn list_workspaces(
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         match content_type {
             ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
             ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ListWorkspacesResponse`"))),
@@ -178,6 +188,7 @@ pub async fn list_workspaces(
         }
     } else {
         let content = resp.text().await?;
+        crate::http_log::log_response_body(&content);
         let entity: Option<ListWorkspacesError> = serde_json::from_str(&content).ok();
         Err(Error::ResponseError(ResponseContent {
             status,

--- a/src/arrow.rs
+++ b/src/arrow.rs
@@ -377,6 +377,7 @@ async fn fetch_arrow_bytes(
         reqwest::StatusCode::ACCEPTED => {
             let retry_after = parse_retry_after(&resp);
             let body = resp.text().await?;
+            crate::http_log::log_response_body(&body);
             let (result_status, result_id) = parse_status_and_id(&body, id);
             Err(ArrowError::NotReady {
                 status: result_status,
@@ -386,20 +387,24 @@ async fn fetch_arrow_bytes(
         }
         reqwest::StatusCode::CONFLICT => {
             let body = resp.text().await?;
+            crate::http_log::log_response_body(&body);
             let error_message = parse_error_message(&body);
             Err(ArrowError::Failed { error_message })
         }
         reqwest::StatusCode::NOT_FOUND => {
             // Drain the body so the connection is returned to the pool.
-            let _ = resp.text().await;
+            let body = resp.text().await.unwrap_or_default();
+            crate::http_log::log_response_body(&body);
             Err(ArrowError::NotFound)
         }
         reqwest::StatusCode::BAD_REQUEST => {
             let message = resp.text().await?;
+            crate::http_log::log_response_body(&message);
             Err(ArrowError::InvalidParams { message })
         }
         other => {
             let body = resp.text().await.unwrap_or_default();
+            crate::http_log::log_response_body(&body);
             Err(ArrowError::Http {
                 status: other,
                 body,

--- a/src/arrow.rs
+++ b/src/arrow.rs
@@ -361,8 +361,10 @@ async fn fetch_arrow_bytes(
     req_builder = req_builder.header(reqwest::header::ACCEPT, ARROW_STREAM_MEDIA_TYPE);
 
     let req = req_builder.build()?;
+    crate::http_log::log_request(&req);
     let resp = configuration.client.execute(req).await?;
     let status = resp.status();
+    crate::http_log::log_response_status(status);
 
     if status == reqwest::StatusCode::OK {
         let total_row_count = parse_total_row_count(&resp);

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -330,18 +330,28 @@ impl TokenManager {
         let mut params: Vec<(&str, &str)> = grant.to_vec();
         params.push(("client_id", &self.client_id));
 
-        let resp = self
+        // Build then execute (rather than `.send()`) so the request can be
+        // debug-logged; `log_request` redacts the api_token/refresh_token form
+        // fields. Mirrors the generated ops and the rest of the SDK.
+        let req = self
             .client
             .post(&url)
             .form(&params)
             .timeout(Duration::from_secs(TIMEOUT_SECS))
-            .send()
+            .build()
+            .map_err(TokenExchangeError::Transport)?;
+        crate::http_log::log_request(&req);
+        let resp = self
+            .client
+            .execute(req)
             .await
             .map_err(TokenExchangeError::Transport)?;
 
         let status = resp.status();
+        crate::http_log::log_response_status(status);
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
+            crate::http_log::log_response_body(&body);
             // Truncate to keep error messages bounded (mirrors python's [:200]).
             let body: String = body.chars().take(200).collect();
             return Err(TokenExchangeError::Status {
@@ -351,6 +361,8 @@ impl TokenManager {
         }
 
         let text = resp.text().await.map_err(TokenExchangeError::Transport)?;
+        // The minted JWT/refresh token in the body are masked by log_response_body.
+        crate::http_log::log_response_body(&text);
         serde_json::from_str::<TokenResponse>(&text)
             .map_err(|e| TokenExchangeError::Malformed(e.to_string()))
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -368,22 +368,27 @@ impl Client {
         req_builder = req_builder.json(&request);
 
         let req = req_builder.build()?;
+        crate::http_log::log_request(&req);
         let resp = configuration.client.execute(req).await?;
 
         let status = resp.status();
+        crate::http_log::log_response_status(status);
 
         if status == reqwest::StatusCode::ACCEPTED {
             // 202 Accepted: the query was submitted asynchronously.
             let content = resp.text().await?;
+            crate::http_log::log_response_body(&content);
             let submitted: models::AsyncQueryResponse = serde_json::from_str(&content)?;
             Ok(QueryOutcome::Submitted(submitted))
         } else if !status.is_client_error() && !status.is_server_error() {
             // 2xx (typically 200): inline results.
             let content = resp.text().await?;
+            crate::http_log::log_response_body(&content);
             let inline: models::QueryResponse = serde_json::from_str(&content)?;
             Ok(QueryOutcome::Inline(inline))
         } else {
             let content = resp.text().await?;
+            crate::http_log::log_response_body(&content);
             let entity: Option<apis::query_api::QueryError> = serde_json::from_str(&content).ok();
             Err(Error::ResponseError(ResponseContent {
                 status,
@@ -476,9 +481,11 @@ impl Client {
         req_builder = req_builder.body(reqwest::Body::wrap_stream(body));
 
         let req = req_builder.build()?;
+        crate::http_log::log_request(&req);
         let resp = configuration.client.execute(req).await?;
 
         let status = resp.status();
+        crate::http_log::log_response_status(status);
         let content_type = resp
             .headers()
             .get("content-type")
@@ -490,6 +497,7 @@ impl Client {
 
         if !status.is_client_error() && !status.is_server_error() {
             let content = resp.text().await?;
+            crate::http_log::log_response_body(&content);
             if is_json {
                 serde_json::from_str(&content).map_err(Error::from)
             } else {
@@ -499,6 +507,7 @@ impl Client {
             }
         } else {
             let content = resp.text().await?;
+            crate::http_log::log_response_body(&content);
             let entity: Option<apis::uploads_api::UploadFileError> =
                 serde_json::from_str(&content).ok();
             Err(Error::ResponseError(ResponseContent {

--- a/src/http_log.rs
+++ b/src/http_log.rs
@@ -39,18 +39,27 @@ pub const TARGET: &str = "hotdata::http";
 const SENSITIVE_KEYS: &[&str] = &[
     "authorization",
     "api_token",
+    "api_key",
     "access_token",
     "refresh_token",
     "token",
     "client_secret",
     "secret",
     "secret_value",
+    // The Secrets API write body field (`CreateSecretRequest`/`UpdateSecretRequest`).
+    // Collides with the benign `CategoryValueInfo.value`, but masking an analytics
+    // value in a debug log is far cheaper than leaking a stored secret.
+    "value",
     "password",
     "passwd",
     "private_key",
     "credentials",
     "connection_string",
 ];
+
+/// Placeholder substituted for a sensitive non-string value (object, array,
+/// number, bool) so nested secrets can never leak through a sensitive key.
+const REDACTED: &str = "<redacted>";
 
 /// Cap on the rendered length of a non-JSON, non-form body so a stray large or
 /// binary-ish payload can't flood the log.
@@ -67,11 +76,17 @@ fn enabled() -> bool {
 /// `mask_credential` so SDK and CLI debug logs read identically; the visible
 /// tail makes it easy to tell which token is on the wire.
 pub fn mask_credential(s: &str) -> String {
-    if s.len() >= 12 {
-        format!("{}...{}", &s[..4], &s[s.len() - 4..])
-    } else if s.len() > 4 {
+    // Index by `char`, not byte: this runs on arbitrary JSON string values, so a
+    // non-ASCII secret would otherwise panic on a non-char-boundary byte slice.
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let head = |k: usize| -> String { chars[..k].iter().collect() };
+    if n >= 12 {
+        let tail: String = chars[n - 4..].iter().collect();
+        format!("{}...{}", head(4), tail)
+    } else if n > 4 {
         // Short-ish: show the head but no tail, so we don't reveal most of it.
-        format!("{}...", &s[..4])
+        format!("{}...", head(4))
     } else {
         "***".into()
     }
@@ -171,14 +186,18 @@ fn redact_body(bytes: &[u8]) -> String {
 }
 
 /// Recursively mask the values of sensitive keys in a JSON value, in place.
+///
+/// A sensitive key's value is masked *whole*, whatever its type: a string keeps
+/// a head/tail hint, while an object/array/number/bool collapses to
+/// [`REDACTED`]. That matters because a sensitive key can hold structured
+/// secrets (e.g. `{"credentials": {"password": "…"}}`) — masking only string
+/// values would log the surrounding object in the clear.
 fn redact_json(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
             for (key, val) in map.iter_mut() {
                 if is_sensitive(key) {
-                    if let Some(s) = val.as_str() {
-                        *val = serde_json::Value::String(mask_credential(s));
-                    }
+                    *val = redacted_value(val);
                 } else {
                     redact_json(val);
                 }
@@ -186,6 +205,17 @@ fn redact_json(value: &mut serde_json::Value) {
         }
         serde_json::Value::Array(items) => items.iter_mut().for_each(redact_json),
         _ => {}
+    }
+}
+
+/// Mask a value that sits under a sensitive key. Strings keep a head/tail hint
+/// (so a token is still identifiable); `null` stays `null` (nothing to hide);
+/// every other type collapses to [`REDACTED`] so nested secrets can't leak.
+fn redacted_value(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => serde_json::Value::String(mask_credential(s)),
+        serde_json::Value::Null => serde_json::Value::Null,
+        _ => serde_json::Value::String(REDACTED.to_string()),
     }
 }
 
@@ -282,6 +312,56 @@ mod tests {
         // The raw secret never appears in the rendered output.
         assert!(!out.contains("supersecretvalue123"));
         assert!(!out.contains("hd_abcdef0123456789"));
+    }
+
+    #[test]
+    fn sensitive_object_value_is_fully_redacted() {
+        // A sensitive key holding structured data must not leak its contents:
+        // the whole value collapses to the placeholder (not just string leaves).
+        let body = serde_json::json!({
+            "credentials": { "password": "p4ssw0rd", "nested": { "token": "tkn" } },
+            "secret": ["leak-a", "leak-b"],
+            "keep": "visible"
+        })
+        .to_string();
+        let out = redact_body(body.as_bytes());
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["credentials"], "<redacted>");
+        assert_eq!(v["secret"], "<redacted>");
+        assert_eq!(v["keep"], "visible");
+        for leak in ["p4ssw0rd", "tkn", "leak-a", "leak-b"] {
+            assert!(!out.contains(leak), "leaked {leak} via structured value:\n{out}");
+        }
+    }
+
+    #[test]
+    fn secret_value_and_api_key_fields_are_masked() {
+        // The Secrets API `value` field and the embedding-provider `api_key`.
+        let body = serde_json::json!({
+            "name": "openai-key",
+            "value": "supersecretvalue123",
+            "api_key": "sk-abcdef0123456789"
+        })
+        .to_string();
+        let out = redact_body(body.as_bytes());
+        assert!(!out.contains("supersecretvalue123"), "secret value leaked:\n{out}");
+        assert!(!out.contains("sk-abcdef0123456789"), "api_key leaked:\n{out}");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["name"], "openai-key");
+        assert_eq!(v["value"], "supe...e123");
+    }
+
+    #[test]
+    fn non_ascii_secret_value_does_not_panic() {
+        // Masking runs on arbitrary JSON strings; a multibyte secret must mask
+        // on char boundaries rather than panic on a byte slice.
+        let secret = "naïve—café—señor—secret—üñ";
+        let body = serde_json::json!({ "secret": secret }).to_string();
+        let out = redact_body(body.as_bytes());
+        assert!(!out.contains(secret), "non-ascii secret leaked:\n{out}");
+        // And the masker itself is char-safe on multibyte input.
+        let _ = mask_credential(secret);
+        assert_eq!(mask_credential("héllo wörld!"), "héll...rld!");
     }
 
     #[test]

--- a/src/http_log.rs
+++ b/src/http_log.rs
@@ -166,23 +166,25 @@ pub fn log_response_body(body: &str) {
 /// JSON bodies are parsed and masked structurally (recursing into nested
 /// objects/arrays). A non-JSON body is treated as `x-www-form-urlencoded` when
 /// it parses as `k=v(&k=v)*` (the shape of the auth mint body) and its
-/// sensitive fields are masked; anything else is shown verbatim, length-capped.
+/// sensitive fields are masked; anything else is shown verbatim. The rendered
+/// output is length-capped on every path so a large inline result (e.g. a big
+/// JSON query response) can't flood a host's log backend.
 fn redact_body(bytes: &[u8]) -> String {
     let text = match std::str::from_utf8(bytes) {
         Ok(t) => t,
         Err(_) => return format!("[binary: {} bytes]", bytes.len()),
     };
 
-    if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(text) {
+    let rendered = if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(text) {
         redact_json(&mut value);
-        return serde_json::to_string(&value).unwrap_or_else(|_| truncate(text));
-    }
+        serde_json::to_string(&value).unwrap_or_else(|_| text.to_string())
+    } else if let Some(form) = redact_form(text) {
+        form
+    } else {
+        text.to_string()
+    };
 
-    if let Some(form) = redact_form(text) {
-        return form;
-    }
-
-    truncate(text)
+    truncate(&rendered)
 }
 
 /// Recursively mask the values of sensitive keys in a JSON value, in place.
@@ -392,6 +394,18 @@ mod tests {
         let body = "x".repeat(MAX_BODY_LEN + 100);
         let out = redact_body(body.as_bytes());
         assert!(out.len() < body.len());
+        assert!(out.contains("bytes total]"));
+    }
+
+    #[test]
+    fn overlong_json_body_is_truncated() {
+        // A large inline JSON result must be capped too, not just the verbatim
+        // fallback — otherwise a big query response could flood the log backend.
+        let big = "y".repeat(MAX_BODY_LEN * 2);
+        let body = serde_json::json!({ "rows": big }).to_string();
+        assert!(body.len() > MAX_BODY_LEN);
+        let out = redact_body(body.as_bytes());
+        assert!(out.len() <= MAX_BODY_LEN + 64, "json body not capped: {} bytes", out.len());
         assert!(out.contains("bytes total]"));
     }
 }

--- a/src/http_log.rs
+++ b/src/http_log.rs
@@ -1,0 +1,317 @@
+//! Request/response debug logging for the Hotdata Rust SDK.
+//!
+//! Every outgoing HTTP call in this crate funnels its request and response
+//! through this module: the generated free functions in `apis::*` (via the
+//! `api.mustache` template), and the hand-written ergonomic layer —
+//! [`Client::submit_query`](crate::client::Client::submit_query),
+//! [`Client::upload_stream`](crate::client::Client::upload_stream), the Arrow
+//! result fetch in [`crate::arrow`], and the API-token -> JWT mint in
+//! [`crate::auth`]. Each emits `log::debug!` records on the [`TARGET`]
+//! (`hotdata::http`) target so a host can switch them on with any `log` backend
+//! and render them however it likes (e.g. the CLI's `--debug` flag, which maps
+//! this target to its `>>> METHOD url` / `<<< status` output).
+//!
+//! The SDK itself installs no logger and prints nothing on its own — these are
+//! plain `log` facade records. With no backend, or with the target filtered
+//! out, the cost is a single atomic load per call (see [`log_request`]); the
+//! bodies are only stringified/redacted when the target is actually enabled.
+//!
+//! **Redaction.** Sensitive material is masked before it ever reaches the log
+//! facade, mirroring the CLI's `mask_credential`: `Authorization` bearer tokens
+//! are masked (scheme preserved), and known-sensitive JSON object keys / form
+//! fields (`api_token`, `refresh_token`, `secret`, `password`, …) have their
+//! values masked in place — recursively, so nested bodies are covered.
+//!
+//! This module is hand-written and listed in `.openapi-generator-ignore`, so it
+//! survives client regeneration; the `api.mustache` template emits the
+//! `crate::http_log::*` calls at every generated op.
+
+use log::{debug, log_enabled, Level};
+
+/// `log` target for every HTTP debug record this crate emits. Hosts filter on
+/// this to route the SDK's wire logs (e.g. the CLI maps it to its `--debug`
+/// output) without picking up unrelated `log` traffic.
+pub const TARGET: &str = "hotdata::http";
+
+/// JSON object keys and `x-www-form-urlencoded` field names whose values are
+/// masked before logging. Compared case-insensitively. Mirrors the credentials
+/// the CLI redacts so SDK and CLI debug output stay consistent.
+const SENSITIVE_KEYS: &[&str] = &[
+    "authorization",
+    "api_token",
+    "access_token",
+    "refresh_token",
+    "token",
+    "client_secret",
+    "secret",
+    "secret_value",
+    "password",
+    "passwd",
+    "private_key",
+    "credentials",
+    "connection_string",
+];
+
+/// Cap on the rendered length of a non-JSON, non-form body so a stray large or
+/// binary-ish payload can't flood the log.
+const MAX_BODY_LEN: usize = 4096;
+
+/// Whether the HTTP debug target is currently enabled. Call sites guard on this
+/// (cheaply) before doing any redaction work.
+fn enabled() -> bool {
+    log_enabled!(target: TARGET, Level::Debug)
+}
+
+/// Mask a credential to its first + last 4 characters (`XXXX...YYYY`), or `***`
+/// if it is too short to reveal anything safely. Mirrors the CLI's
+/// `mask_credential` so SDK and CLI debug logs read identically; the visible
+/// tail makes it easy to tell which token is on the wire.
+pub fn mask_credential(s: &str) -> String {
+    if s.len() >= 12 {
+        format!("{}...{}", &s[..4], &s[s.len() - 4..])
+    } else if s.len() > 4 {
+        // Short-ish: show the head but no tail, so we don't reveal most of it.
+        format!("{}...", &s[..4])
+    } else {
+        "***".into()
+    }
+}
+
+/// Whether a JSON key / form field name names sensitive material to mask.
+fn is_sensitive(key: &str) -> bool {
+    SENSITIVE_KEYS.iter().any(|k| key.eq_ignore_ascii_case(k))
+}
+
+/// Mask an `Authorization` header value, preserving the scheme prefix
+/// (`Bearer`, `Basic`, …) so the log still reads sensibly.
+fn mask_auth_value(value: &str) -> String {
+    if let Some(token) = value.strip_prefix("Bearer ") {
+        format!("Bearer {}", mask_credential(token))
+    } else {
+        mask_credential(value)
+    }
+}
+
+/// Log an outgoing request: `>>> METHOD url`, each header (with `Authorization`
+/// masked), and the request body with sensitive fields redacted.
+///
+/// Called after `req_builder.build()?` and before `client.execute(req)` (which
+/// consumes the request). Streaming bodies (file/byte-stream uploads) report
+/// their kind rather than buffering — `reqwest::Body::as_bytes` only yields the
+/// in-memory bodies (`.json(..)` / `.form(..)` / `.body(bytes)`).
+pub fn log_request(req: &reqwest::Request) {
+    if !enabled() {
+        return;
+    }
+    debug!(target: TARGET, ">>> {} {}", req.method(), req.url());
+    for (name, value) in req.headers() {
+        let key = name.as_str();
+        let shown = match value.to_str() {
+            Ok(v) if key.eq_ignore_ascii_case("authorization") => mask_auth_value(v),
+            Ok(v) => v.to_string(),
+            Err(_) => "<non-utf8>".to_string(),
+        };
+        debug!(target: TARGET, "  {key}: {shown}");
+    }
+    match req.body().and_then(reqwest::Body::as_bytes) {
+        Some(bytes) if !bytes.is_empty() => debug!(target: TARGET, "{}", redact_body(bytes)),
+        Some(_) => {}
+        // No in-memory body: either a bodyless request or a streamed upload.
+        None if req.body().is_some() => debug!(target: TARGET, "[streaming body]"),
+        None => {}
+    }
+}
+
+/// Log a response status line: `<<< 200 OK`.
+///
+/// Emitted once per call, right after the status is read, so it covers every
+/// branch (including empty-body and streamed-body responses) uniformly.
+pub fn log_response_status(status: reqwest::StatusCode) {
+    if !enabled() {
+        return;
+    }
+    debug!(
+        target: TARGET,
+        "<<< {} {}",
+        status.as_u16(),
+        status.canonical_reason().unwrap_or("")
+    );
+}
+
+/// Log a response body with sensitive fields redacted. No-op for an empty body.
+pub fn log_response_body(body: &str) {
+    if !enabled() || body.is_empty() {
+        return;
+    }
+    debug!(target: TARGET, "{}", redact_body(body.as_bytes()));
+}
+
+/// Render a request/response body for logging with sensitive values masked.
+///
+/// JSON bodies are parsed and masked structurally (recursing into nested
+/// objects/arrays). A non-JSON body is treated as `x-www-form-urlencoded` when
+/// it parses as `k=v(&k=v)*` (the shape of the auth mint body) and its
+/// sensitive fields are masked; anything else is shown verbatim, length-capped.
+fn redact_body(bytes: &[u8]) -> String {
+    let text = match std::str::from_utf8(bytes) {
+        Ok(t) => t,
+        Err(_) => return format!("[binary: {} bytes]", bytes.len()),
+    };
+
+    if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(text) {
+        redact_json(&mut value);
+        return serde_json::to_string(&value).unwrap_or_else(|_| truncate(text));
+    }
+
+    if let Some(form) = redact_form(text) {
+        return form;
+    }
+
+    truncate(text)
+}
+
+/// Recursively mask the values of sensitive keys in a JSON value, in place.
+fn redact_json(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                if is_sensitive(key) {
+                    if let Some(s) = val.as_str() {
+                        *val = serde_json::Value::String(mask_credential(s));
+                    }
+                } else {
+                    redact_json(val);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => items.iter_mut().for_each(redact_json),
+        _ => {}
+    }
+}
+
+/// Mask sensitive fields in an `x-www-form-urlencoded` body, returning `None`
+/// if `text` doesn't look like one (so the caller can fall back to verbatim).
+///
+/// "Looks like a form" means every `&`-separated segment is a non-empty `key=…`
+/// pair — true for the SDK's only non-JSON in-memory body (the token mint), and
+/// false for arbitrary prose, which then logs verbatim.
+fn redact_form(text: &str) -> Option<String> {
+    let segments: Vec<&str> = text.split('&').collect();
+    let looks_like_form = segments.iter().all(|seg| {
+        seg.split_once('=')
+            .is_some_and(|(k, _)| !k.is_empty() && !k.contains(char::is_whitespace))
+    });
+    if !looks_like_form {
+        return None;
+    }
+    let redacted = segments
+        .iter()
+        .map(|seg| match seg.split_once('=') {
+            Some((k, v)) if is_sensitive(k) => format!("{k}={}", mask_credential(v)),
+            _ => seg.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+    Some(redacted)
+}
+
+/// Truncate an over-long body for logging, appending an elision marker.
+fn truncate(text: &str) -> String {
+    if text.len() <= MAX_BODY_LEN {
+        return text.to_string();
+    }
+    // Cut on a char boundary at or below the cap.
+    let mut end = MAX_BODY_LEN;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}… [{} bytes total]", &text[..end], text.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_credential_long_shows_head_and_tail() {
+        assert_eq!(mask_credential("abcdefghijkl"), "abcd...ijkl");
+        assert_eq!(
+            mask_credential("hd_0123456789abcdef"),
+            "hd_0...cdef"
+        );
+    }
+
+    #[test]
+    fn mask_credential_medium_shows_head_only() {
+        // 5..=11 chars: head only, no tail.
+        assert_eq!(mask_credential("abcdef"), "abcd...");
+    }
+
+    #[test]
+    fn mask_credential_short_is_fully_hidden() {
+        assert_eq!(mask_credential("abcd"), "***");
+        assert_eq!(mask_credential(""), "***");
+    }
+
+    #[test]
+    fn mask_auth_preserves_bearer_scheme() {
+        assert_eq!(
+            mask_auth_value("Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature"),
+            "Bearer eyJh...ture"
+        );
+        // Non-bearer values are masked whole.
+        assert_eq!(mask_auth_value("Basic dXNlcjpwYXNz"), "Basi...YXNz");
+    }
+
+    #[test]
+    fn json_body_masks_sensitive_keys_recursively() {
+        let body = serde_json::json!({
+            "name": "prod-db",
+            "secret": "supersecretvalue123",
+            "nested": { "api_token": "hd_abcdef0123456789", "keep": "visible" },
+            "list": [ { "password": "hunter2hunter2" } ]
+        })
+        .to_string();
+        let out = redact_body(body.as_bytes());
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["name"], "prod-db");
+        assert_eq!(v["secret"], "supe...e123");
+        assert_eq!(v["nested"]["api_token"], "hd_a...6789");
+        assert_eq!(v["nested"]["keep"], "visible");
+        assert_eq!(v["list"][0]["password"], "hunt...ter2");
+        // The raw secret never appears in the rendered output.
+        assert!(!out.contains("supersecretvalue123"));
+        assert!(!out.contains("hd_abcdef0123456789"));
+    }
+
+    #[test]
+    fn form_body_masks_sensitive_fields() {
+        let body = "grant_type=api_token&api_token=hd_0123456789abcdef&client_id=hotdata-rust-sdk";
+        let out = redact_body(body.as_bytes());
+        assert!(out.contains("grant_type=api_token"));
+        assert!(out.contains("client_id=hotdata-rust-sdk"));
+        assert!(out.contains("api_token=hd_0...cdef"));
+        assert!(!out.contains("hd_0123456789abcdef"));
+    }
+
+    #[test]
+    fn non_form_text_is_logged_verbatim() {
+        // Plain prose isn't mistaken for a form (no spurious masking/mangling).
+        let body = "this is not a form body";
+        assert_eq!(redact_body(body.as_bytes()), body);
+    }
+
+    #[test]
+    fn binary_body_reports_byte_count() {
+        let out = redact_body(&[0xff, 0xfe, 0x00, 0x01]);
+        assert_eq!(out, "[binary: 4 bytes]");
+    }
+
+    #[test]
+    fn overlong_plain_body_is_truncated() {
+        let body = "x".repeat(MAX_BODY_LEN + 100);
+        let out = redact_body(body.as_bytes());
+        assert!(out.len() < body.len());
+        assert!(out.contains("bytes total]"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod arrow;
 pub mod auth;
 pub mod client;
 pub mod field;
+pub mod http_log;
 pub mod models;
 pub mod resources;
 pub mod status;

--- a/tests/debug_logging.rs
+++ b/tests/debug_logging.rs
@@ -1,0 +1,125 @@
+//! End-to-end check that the SDK emits redacted request/response debug logs on
+//! the `hotdata::http` target for real HTTP traffic (issue #135).
+//!
+//! This is the SDK side of restoring the CLI's `--debug` logging: the SDK emits
+//! plain `log` records and a host installs a backend to render them. Here we
+//! install a capturing `log` backend, drive a generated op against a wiremock
+//! server, and assert that the request line, headers, status, and bodies were
+//! logged — with the bearer token and sensitive body fields masked, never the
+//! raw secret.
+//!
+//! It lives in its own test binary so it is the only thing installing a process
+//! global logger; `log::set_boxed_logger` can only be called once per process.
+
+use std::sync::{Mutex, OnceLock};
+
+use hotdata::apis::{query_api, workspaces_api};
+use hotdata::{models, Configuration};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Captures `hotdata::http` log records so the test can assert on them.
+static LOG_BUF: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn log_buf() -> &'static Mutex<Vec<String>> {
+    LOG_BUF.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+struct CaptureLogger;
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, meta: &log::Metadata) -> bool {
+        meta.target() == hotdata::http_log::TARGET
+    }
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            log_buf().lock().unwrap().push(record.args().to_string());
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+fn install_logger() {
+    // `set_logger` (vs `set_boxed_logger`) needs no `std` feature on `log`.
+    log::set_logger(&LOGGER).expect("logger installs once");
+    log::set_max_level(log::LevelFilter::Debug);
+}
+
+fn captured() -> String {
+    log_buf().lock().unwrap().join("\n")
+}
+
+#[tokio::test]
+async fn debug_logs_redact_request_and_response() {
+    install_logger();
+    let server = MockServer::start().await;
+
+    // --- GET op: exercises request line, header redaction, status, and a
+    //     response body whose sensitive field must be masked. ---
+    Mock::given(method("GET"))
+        .and(path("/v1/workspaces"))
+        .respond_with(
+            // Body carries a `token` field so we can prove response-body
+            // redaction; the op won't deserialize this into the real type, but
+            // logging fires before deserialization either way.
+            ResponseTemplate::new(200)
+                .set_body_string(r#"{"token":"supersecrettoken123","ok":true}"#),
+        )
+        .mount(&server)
+        .await;
+
+    let mut config = Configuration::new();
+    config.base_path = server.uri();
+    config.bearer_access_token = Some("bearersecretvalue999".to_string());
+
+    let _ = workspaces_api::list_workspaces(&config, None).await;
+
+    // --- POST op: exercises a JSON request body being logged. ---
+    Mock::given(method("POST"))
+        .and(path("/v1/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ignored":true}"#))
+        .mount(&server)
+        .await;
+
+    let request = models::QueryRequest {
+        sql: "SELECT 1".to_string(),
+        ..Default::default()
+    };
+    let _ = query_api::query(&config, request, None).await;
+
+    let logs = captured();
+
+    // Request line + status line, CLI-style markers.
+    assert!(logs.contains(">>> GET"), "missing request line:\n{logs}");
+    assert!(logs.contains(">>> POST"), "missing POST request line:\n{logs}");
+    assert!(logs.contains("<<< 200"), "missing response status:\n{logs}");
+
+    // The Authorization header is logged with the scheme preserved but the
+    // token masked — never the raw bearer value.
+    assert!(
+        logs.contains("Bearer bear...e999"),
+        "authorization not masked as expected:\n{logs}"
+    );
+    assert!(
+        !logs.contains("bearersecretvalue999"),
+        "raw bearer token leaked into logs:\n{logs}"
+    );
+
+    // The response body's sensitive field is masked, raw value never logged.
+    assert!(
+        logs.contains("supe...n123"),
+        "response token not masked:\n{logs}"
+    );
+    assert!(
+        !logs.contains("supersecrettoken123"),
+        "raw response token leaked into logs:\n{logs}"
+    );
+
+    // The JSON request body is logged (non-sensitive field shown verbatim).
+    assert!(
+        logs.contains("SELECT 1"),
+        "request body not logged:\n{logs}"
+    );
+}


### PR DESCRIPTION
Adds request/response debug logging (`hotdata::http_log`) on the `hotdata::http` `log` target covering every HTTP call — generated ops plus the hand-written `submit_query`/`upload_stream`/Arrow fetch/JWT mint — with bearer tokens and sensitive body fields masked. The hook lives in `api.mustache` so it survives regen, and the regen-safety guard verifies it.

This is the SDK prerequisite for restoring the CLI's `--debug` output; the remaining hotdata-cli step (wire a `log` backend when `--debug` is set) is a thin follow-up.

Closes #33