### PR TITLE
docs: add crate metadata and link the Hotdata CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,12 @@ authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"
 edition = "2021"
+readme = "README.md"
+repository = "https://github.com/hotdata-dev/sdk-rust"
+homepage = "https://www.hotdata.dev"
+documentation = "https://docs.rs/hotdata"
+keywords = ["hotdata", "sdk", "api-client", "arrow", "async"]
+categories = ["api-bindings", "asynchronous", "database"]
 
 [dependencies]
 serde = { version = "^1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ hotdata = { version = "0.1", default-features = false, features = ["rustls"] }
 
 The API authenticates with an **API token** sent as `Authorization: Bearer <token>`, plus an **`X-Workspace-Id`** header on requests scoped to a workspace.
 
-API tokens (prefixed `hd_`) are exchanged transparently for short-lived JWTs the first time a request is made, and the JWT is cached and refreshed automatically. You only ever supply the API token — the `Client` does the exchange against `/v1/auth/jwt` for you, mirroring the Hotdata CLI.
+API tokens (prefixed `hd_`) are exchanged transparently for short-lived JWTs the first time a request is made, and the JWT is cached and refreshed automatically. You only ever supply the API token — the `Client` does the exchange against `/v1/auth/jwt` for you, mirroring the [Hotdata CLI](https://github.com/hotdata-dev/hotdata-cli).
 
 If you already hold a JWT (a value beginning with `eyJ`), it is passed through unchanged with no exchange. To disable the exchange entirely, set `HOTDATA_DISABLE_JWT_EXCHANGE` to `1`, `true`, `yes`, or `on`.
 


### PR DESCRIPTION
Add `repository`, `homepage`, `documentation`, `readme`, `keywords`, and `categories` to `[package]` (clears the crates.io "no documentation/homepage/repository" warning), and link the [Hotdata CLI](https://github.com/hotdata-dev/hotdata-cli) from the README. Ships with the v0.1.1 release.