### PR TITLE
chore: release hotdata v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-05
+
+### Changed
+
+- Populate crate metadata (`repository`, `homepage`, `documentation`, `readme`, `keywords`, `categories`) for the crates.io listing, and link the [Hotdata CLI](https://github.com/hotdata-dev/hotdata-cli) from the README.
+- Publishing to crates.io now uses Trusted Publishing (OIDC) instead of a stored API token.
+
 ## [0.1.0] - 2026-06-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"


### PR DESCRIPTION
Bump to v0.1.1 and cut the changelog section. Ships the crate metadata + CLI link, and is the first release published via OIDC Trusted Publishing. After merge, push the `v0.1.1` tag to publish.