### PR TITLE
fix(ci): keep string dates under generator 7.22.0 (useChrono=false)

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -78,12 +78,16 @@ jobs:
         env:
           PACKAGE_VERSION: ${{ steps.pkg.outputs.version }}
         run: |
+          # useChrono=false: 7.22.0 flipped the Rust generator's useChrono
+          # default to true, which emits chrono::DateTime for date-time fields.
+          # The crate has no chrono dependency and the ergonomic layer + tests
+          # treat dates as String (as 7.20.0 generated them), so keep String.
           npx @openapitools/openapi-generator-cli generate \
             -i openapi.yaml \
             -g rust \
             -o . \
             -t .openapi-generator-templates \
-            --additional-properties=packageName=hotdata,packageVersion=$PACKAGE_VERSION,library=reqwest,supportAsync=true \
+            --additional-properties=packageName=hotdata,packageVersion=$PACKAGE_VERSION,library=reqwest,supportAsync=true,useChrono=false \
             --http-user-agent "hotdata-rust/${PACKAGE_VERSION}" \
             --skip-validate-spec
 


### PR DESCRIPTION
Generator 7.22.0 flipped `useChrono` to default true, emitting `chrono::DateTime` for date-time fields — the crate has no chrono dependency and the ergonomic layer/tests use `String` dates, so the regen build failed (run 27046314453). Pin `useChrono=false` to keep the prior string behavior. Verified locally: full regen + `cargo check --all-features` + test build all pass.