### PR TITLE
fix: remove orphaned sandbox resource wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ let runs     = client.query_runs().list(Some(50), None, None, None).await?;
 Handles exist for every resource — `datasets`, `connections`, `connection_types`,
 `databases`, `database_context`, `embedding_providers`, `indexes`,
 `information_schema`, `jobs`, `queries`, `query_runs`, `results`, `refresh`,
-`sandboxes`, `saved_queries`, `secrets`, `uploads`, `workspaces`. The hottest
+`saved_queries`, `secrets`, `uploads`, `workspaces`. The hottest
 operations also have flat shortcuts directly on `Client` (`query`, `get_result`,
 `list_results`, `list_query_runs`, `list_workspaces`).
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -673,11 +673,6 @@ impl Client {
         crate::resources::RefreshApi::new(&self.configuration)
     }
 
-    /// Sandboxes resource handle.
-    pub fn sandboxes(&self) -> crate::resources::SandboxesApi<'_> {
-        crate::resources::SandboxesApi::new(&self.configuration)
-    }
-
     /// Saved-queries resource handle.
     pub fn saved_queries(&self) -> crate::resources::SavedQueriesApi<'_> {
         crate::resources::SavedQueriesApi::new(&self.configuration)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use client::{
 pub use resources::{
     ConnectionTypesApi, ConnectionsApi, DatabaseContextApi, DatabasesApi, DatasetsApi,
     EmbeddingProvidersApi, IndexesApi, InformationSchemaApi, JobsApi, QueryApi, QueryRunsApi,
-    RefreshApi, ResultsApi, SandboxesApi, SavedQueriesApi, SecretsApi, UploadsApi, WorkspacesApi,
+    RefreshApi, ResultsApi, SavedQueriesApi, SecretsApi, UploadsApi, WorkspacesApi,
 };
 pub use status::{QueryRunStatus, QueryRunStatusExt, ResultStatus, ResultStatusExt};
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -656,57 +656,6 @@ impl<'a> RefreshApi<'a> {
     }
 }
 
-/// Sandboxes resource handle. Wraps [`apis::sandboxes_api`](crate::apis::sandboxes_api).
-pub struct SandboxesApi<'a> {
-    config: &'a Configuration,
-}
-
-impl<'a> SandboxesApi<'a> {
-    pub(crate) fn new(config: &'a Configuration) -> Self {
-        Self { config }
-    }
-
-    /// Create a new sandbox.
-    pub async fn create(
-        &self,
-        request: models::CreateSandboxRequest,
-    ) -> Result<models::SandboxResponse, Error<apis::sandboxes_api::CreateSandboxError>> {
-        apis::sandboxes_api::create_sandbox(self.config, request).await
-    }
-
-    /// Fetch a sandbox by public id.
-    pub async fn get(
-        &self,
-        public_id: &str,
-    ) -> Result<models::SandboxResponse, Error<apis::sandboxes_api::GetSandboxError>> {
-        apis::sandboxes_api::get_sandbox(self.config, public_id).await
-    }
-
-    /// List sandboxes.
-    pub async fn list(
-        &self,
-    ) -> Result<models::ListSandboxesResponse, Error<apis::sandboxes_api::ListSandboxesError>> {
-        apis::sandboxes_api::list_sandboxes(self.config).await
-    }
-
-    /// Update a sandbox by public id.
-    pub async fn update(
-        &self,
-        public_id: &str,
-        request: models::UpdateSandboxRequest,
-    ) -> Result<models::SandboxResponse, Error<apis::sandboxes_api::UpdateSandboxError>> {
-        apis::sandboxes_api::update_sandbox(self.config, public_id, request).await
-    }
-
-    /// Delete a sandbox by public id.
-    pub async fn delete(
-        &self,
-        public_id: &str,
-    ) -> Result<models::DeleteSandboxResponse, Error<apis::sandboxes_api::DeleteSandboxError>> {
-        apis::sandboxes_api::delete_sandbox(self.config, public_id).await
-    }
-}
-
 /// Saved-queries resource handle. Wraps [`apis::saved_queries_api`](crate::apis::saved_queries_api).
 pub struct SavedQueriesApi<'a> {
     config: &'a Configuration,
@@ -951,7 +900,6 @@ mod tests {
         let _ = QueryRunsApi::new(&config);
         let _ = ResultsApi::new(&config);
         let _ = RefreshApi::new(&config);
-        let _ = SandboxesApi::new(&config);
         let _ = SavedQueriesApi::new(&config);
         let _ = SecretsApi::new(&config);
         let _ = UploadsApi::new(&config);


### PR DESCRIPTION
The sandbox endpoints were removed from the OpenAPI spec, so client regeneration no longer emits the `sandboxes_api` module or `*Sandbox*` models. The hand-written `SandboxesApi` wrapper still referenced them, breaking the regen compile gate and blocking the regenerated PR. Removes the wrapper, its `Client::sandboxes()` accessor, the re-export, and the README mention.