### PR TITLE
ci: seed changelog entry on regen version bump

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -78,8 +78,9 @@ jobs:
       # check-release.yml gates merges on a `## [x.y.z]` CHANGELOG section
       # matching the bumped version, so without a seeded entry every regen PR
       # fails that check. Insert a stub (the spec-change title under ### Changed)
-      # right after `## [Unreleased]`; the PR author refines the wording before
-      # merge. Idempotent: skips if a section for this version already exists.
+      # just above the most recent released section; the PR author refines the
+      # wording before merge. Idempotent: skips if a section for this version
+      # already exists.
       - name: Seed changelog entry
         env:
           VERSION: ${{ steps.pkg.outputs.version }}
@@ -97,13 +98,16 @@ jobs:
           if re.search(rf"^## \[{re.escape(version)}\]", text, re.M):
               print(f"CHANGELOG already has a [{version}] section; leaving it untouched.")
               raise SystemExit(0)
-          marker = "## [Unreleased]\n"
-          idx = text.find(marker)
-          if idx == -1:
+          unreleased = re.search(r"^## \[Unreleased\]", text, re.M)
+          if not unreleased:
               raise SystemExit("CHANGELOG.md has no '## [Unreleased]' section to anchor the new entry")
-          insert_at = idx + len(marker)
-          entry = f"## [{version}] - {date}\n\n### Changed\n\n- {title}\n"
-          text = text[:insert_at] + "\n" + entry + "\n" + text[insert_at:].lstrip("\n")
+          # Insert before the first released section after [Unreleased] (falling
+          # back to end of file) so any pending entries under [Unreleased] stay
+          # attributed to it rather than being absorbed by the new version.
+          nxt = re.search(r"^## \[", text[unreleased.end():], re.M)
+          insert_at = unreleased.end() + nxt.start() if nxt else len(text)
+          entry = f"## [{version}] - {date}\n\n### Changed\n\n- {title}\n\n"
+          text = text[:insert_at] + entry + text[insert_at:]
           path.write_text(text)
           print(f"Inserted CHANGELOG [{version}] section.")
           PY

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -75,6 +75,39 @@ jobs:
             | jq -r '.packages[] | select(.name=="hotdata") | .version')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # check-release.yml gates merges on a `## [x.y.z]` CHANGELOG section
+      # matching the bumped version, so without a seeded entry every regen PR
+      # fails that check. Insert a stub (the spec-change title under ### Changed)
+      # right after `## [Unreleased]`; the PR author refines the wording before
+      # merge. Idempotent: skips if a section for this version already exists.
+      - name: Seed changelog entry
+        env:
+          VERSION: ${{ steps.pkg.outputs.version }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          export CHANGELOG_DATE=$(date -u +%Y-%m-%d)
+          python3 - <<'PY'
+          import os, pathlib, re
+          version = os.environ["VERSION"]
+          date = os.environ["CHANGELOG_DATE"]
+          title = (os.environ.get("TITLE") or "").strip() \
+              or "Regenerate the client from the updated Hotdata OpenAPI spec"
+          path = pathlib.Path("CHANGELOG.md")
+          text = path.read_text()
+          if re.search(rf"^## \[{re.escape(version)}\]", text, re.M):
+              print(f"CHANGELOG already has a [{version}] section; leaving it untouched.")
+              raise SystemExit(0)
+          marker = "## [Unreleased]\n"
+          idx = text.find(marker)
+          if idx == -1:
+              raise SystemExit("CHANGELOG.md has no '## [Unreleased]' section to anchor the new entry")
+          insert_at = idx + len(marker)
+          entry = f"## [{version}] - {date}\n\n### Changed\n\n- {title}\n"
+          text = text[:insert_at] + "\n" + entry + "\n" + text[insert_at:].lstrip("\n")
+          path.write_text(text)
+          print(f"Inserted CHANGELOG [{version}] section.")
+          PY
+
       - name: Generate client
         env:
           PACKAGE_VERSION: ${{ steps.pkg.outputs.version }}


### PR DESCRIPTION
Regeneration bumps the patch version but never added a CHANGELOG entry, so `check-release` (which requires a `## [x.y.z]` section matching the bump) failed on every regen PR — e.g. #50 had to be fixed by hand. Adds a step that seeds a stub entry (the spec-change title under `### Changed`) after `## [Unreleased]` right after the version bump. Idempotent, and the PR author refines the wording before merge.