### PR TITLE
chore: release hotdata v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.2.0] - 2026-06-15
+
 ### Added
 
 - Enhanced `Client::query`: transparently retries HTTP 429 (`OVERLOADED`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"

--- a/src/apis/configuration.rs
+++ b/src/apis/configuration.rs
@@ -65,7 +65,7 @@ impl Default for Configuration {
     fn default() -> Self {
         Configuration {
             base_path: "https://api.hotdata.dev".to_owned(),
-            user_agent: Some("hotdata-rust/0.1.4".to_owned()),
+            user_agent: Some("hotdata-rust/0.2.0".to_owned()),
             client: reqwest::Client::new(),
             basic_auth: None,
             oauth_access_token: None,


### PR DESCRIPTION
Release **hotdata v0.2.0**: version bumped in `Cargo.toml` and `CHANGELOG.md` rolled over from `[Unreleased]`. Minor bump for the breaking `Client::query` return-type change. After merge, run `./scripts/release.sh publish` from a clean `main` checkout.