### PR TITLE
ci(publish): post to #deploy on crates.io publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
       # Announce the release in #deploy. Runs only when the publish above
       # succeeded. Posts via the shared Hotdata CI Slack app (bot token), so the
       # same SLACK_CI_BOT_TOKEN org secret drives notifications across SDK repos.
-      - name: Notify #deploy on Slack
+      - name: "Notify #deploy on Slack"
         env:
           SLACK_CI_BOT_TOKEN: ${{ secrets.SLACK_CI_BOT_TOKEN }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,3 +64,20 @@ jobs:
         # --all-features mirrors the dry-run so the pre-upload verify build
         # also compiles the optional arrow surface.
         run: cargo publish --all-features
+
+      # Announce the release in #deploy. Runs only when the publish above
+      # succeeded. Posts via an incoming webhook so no Slack action is pinned;
+      # set the SLACK_DEPLOY_WEBHOOK_URL secret to a webhook bound to #deploy.
+      - name: Notify #deploy on Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "SLACK_DEPLOY_WEBHOOK_URL not set; skipping Slack notification" >&2
+            exit 0
+          fi
+          version="${GITHUB_REF_NAME#v}"
+          text=":package: *hotdata* \`v${version}\` published to crates.io — <https://crates.io/crates/hotdata/${version}|crates.io> · <https://github.com/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}|release notes>"
+          payload=$(jq -n --arg text "$text" '{text: $text}')
+          curl -sSf -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,18 +66,23 @@ jobs:
         run: cargo publish --all-features
 
       # Announce the release in #deploy. Runs only when the publish above
-      # succeeded. Posts via an incoming webhook so no Slack action is pinned;
-      # set the SLACK_DEPLOY_WEBHOOK_URL secret to a webhook bound to #deploy.
+      # succeeded. Posts via the shared Hotdata CI Slack app (bot token), so the
+      # same SLACK_CI_BOT_TOKEN org secret drives notifications across SDK repos.
       - name: Notify #deploy on Slack
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
+          SLACK_CI_BOT_TOKEN: ${{ secrets.SLACK_CI_BOT_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-            echo "SLACK_DEPLOY_WEBHOOK_URL not set; skipping Slack notification" >&2
+          if [ -z "${SLACK_CI_BOT_TOKEN:-}" ]; then
+            echo "SLACK_CI_BOT_TOKEN not set; skipping Slack notification" >&2
             exit 0
           fi
           version="${GITHUB_REF_NAME#v}"
           text=":package: *hotdata* \`v${version}\` published to crates.io — <https://crates.io/crates/hotdata/${version}|crates.io> · <https://github.com/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}|release notes>"
-          payload=$(jq -n --arg text "$text" '{text: $text}')
-          curl -sSf -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+          # #deploy channel ID (rename-proof). chat.postMessage returns HTTP 200
+          # even on logical errors, so assert on .ok to fail the step.
+          curl -sSf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_CI_BOT_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            --data "$(jq -n --arg ch 'C0ARK84E1D4' --arg text "$text" '{channel:$ch, text:$text}')" \
+          | jq -e '.ok' >/dev/null

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,9 @@ jobs:
       # succeeded. Posts via the shared Hotdata CI Slack app (bot token), so the
       # same SLACK_CI_BOT_TOKEN org secret drives notifications across SDK repos.
       - name: "Notify #deploy on Slack"
+        # The publish above is irreversible, so a Slack/token hiccup must not
+        # mark a successful release as failed and trigger false-alarm retries.
+        continue-on-error: true
         env:
           SLACK_CI_BOT_TOKEN: ${{ secrets.SLACK_CI_BOT_TOKEN }}
         run: |


### PR DESCRIPTION
Adds a step to the publish workflow that posts a release announcement to #deploy after a successful `cargo publish`. Posts via the shared Hotdata CI Slack app using the `SLACK_CI_BOT_TOKEN` org secret; the step skips gracefully if it's unset.