### PR TITLE
feat: auto-retry HTTP 429 on every generated API operation

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -4,6 +4,7 @@ README.md
 Cargo.toml
 src/lib.rs
 src/auth.rs
+src/http.rs
 src/http_log.rs
 src/arrow.rs
 src/client.rs

--- a/.openapi-generator-templates/reqwest/api.mustache
+++ b/.openapi-generator-templates/reqwest/api.mustache
@@ -586,7 +586,15 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req){{#supportAsync}}.await{{/supportAsync}}?;
+    {{#supportAsync}}
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp = crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
+    {{/supportAsync}}
+    {{^supportAsync}}
+    let resp = configuration.client.execute(req)?;
+    {{/supportAsync}}
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/.openapi-generator-templates/reqwest/configuration.mustache
+++ b/.openapi-generator-templates/reqwest/configuration.mustache
@@ -24,6 +24,12 @@ pub struct Configuration {
     pub bearer_access_token: Option<String>,
     pub token_provider: Option<std::sync::Arc<dyn crate::auth::BearerTokenProvider>>,
     pub api_keys: HashMap<String, ApiKey>,
+    /// HTTP 429 (`OVERLOADED`) retry policy applied to every generated `apis::*`
+    /// operation: the request is retried with `Retry-After`/backoff before the
+    /// op returns. Defaults to [`RetryPolicy::default`]; set `max_retries` to 0
+    /// to disable retry. The enhanced query path ([`crate::query`]) uses its own
+    /// per-call [`QueryConfig::retry`](crate::query::QueryConfig::retry) instead.
+    pub retry: crate::query::RetryPolicy,
     {{/supportTokenSource}}
     {{#withAWSV4Signature}}
     pub aws_v4_key: Option<AWSv4Key>,
@@ -129,6 +135,7 @@ impl Default for Configuration {
             bearer_access_token: None,
             token_provider: None,
             api_keys: HashMap::new(),
+            retry: crate::query::RetryPolicy::default(),
             {{/supportTokenSource}}
             {{#withAWSV4Signature}}
             aws_v4_key: None,

--- a/src/apis/configuration.rs
+++ b/src/apis/configuration.rs
@@ -20,6 +20,12 @@ pub struct Configuration {
     pub bearer_access_token: Option<String>,
     pub token_provider: Option<std::sync::Arc<dyn crate::auth::BearerTokenProvider>>,
     pub api_keys: HashMap<String, ApiKey>,
+    /// HTTP 429 (`OVERLOADED`) retry policy applied to every generated `apis::*`
+    /// operation: the request is retried with `Retry-After`/backoff before the
+    /// op returns. Defaults to [`RetryPolicy::default`]; set `max_retries` to 0
+    /// to disable retry. The enhanced query path ([`crate::query`]) uses its own
+    /// per-call [`QueryConfig::retry`](crate::query::QueryConfig::retry) instead.
+    pub retry: crate::query::RetryPolicy,
 }
 
 pub type BasicAuth = (String, Option<String>);
@@ -72,6 +78,7 @@ impl Default for Configuration {
             bearer_access_token: None,
             token_provider: None,
             api_keys: HashMap::new(),
+            retry: crate::query::RetryPolicy::default(),
         }
     }
 }

--- a/src/apis/connection_types_api.rs
+++ b/src/apis/connection_types_api.rs
@@ -60,7 +60,11 @@ pub async fn get_connection_type(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -115,7 +119,11 @@ pub async fn list_connection_types(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/connections_api.rs
+++ b/src/apis/connections_api.rs
@@ -156,7 +156,11 @@ pub async fn add_managed_schema(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -227,7 +231,11 @@ pub async fn add_managed_table(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -290,7 +298,11 @@ pub async fn check_connection_health(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -352,7 +364,11 @@ pub async fn create_connection(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -417,7 +433,11 @@ pub async fn delete_connection(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -476,7 +496,11 @@ pub async fn delete_managed_table(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -527,7 +551,11 @@ pub async fn get_connection(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -596,7 +624,11 @@ pub async fn get_table_profile(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -651,7 +683,11 @@ pub async fn list_connections(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -725,7 +761,11 @@ pub async fn load_managed_table(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -790,7 +830,11 @@ pub async fn purge_connection_cache(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -849,7 +893,11 @@ pub async fn purge_table_cache(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/database_context_api.rs
+++ b/src/apis/database_context_api.rs
@@ -85,7 +85,11 @@ pub async fn delete_database_context(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -138,7 +142,11 @@ pub async fn get_database_context(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -200,7 +208,11 @@ pub async fn list_database_contexts(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -268,7 +280,11 @@ pub async fn upsert_database_context(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/databases_api.rs
+++ b/src/apis/databases_api.rs
@@ -121,7 +121,11 @@ pub async fn add_database_schema(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -192,7 +196,11 @@ pub async fn add_database_table(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -260,7 +268,11 @@ pub async fn attach_database_catalog(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -310,7 +322,11 @@ pub async fn create_database(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -375,7 +391,11 @@ pub async fn delete_database(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -430,7 +450,11 @@ pub async fn detach_database_catalog(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -481,7 +505,11 @@ pub async fn get_database(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -535,7 +563,11 @@ pub async fn list_databases(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/datasets_api.rs
+++ b/src/apis/datasets_api.rs
@@ -107,7 +107,11 @@ pub async fn create_dataset(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -179,7 +183,11 @@ pub async fn delete_dataset(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -229,7 +237,11 @@ pub async fn get_dataset(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -301,7 +313,11 @@ pub async fn list_dataset_versions(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -375,7 +391,11 @@ pub async fn list_datasets(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -448,7 +468,11 @@ pub async fn update_dataset(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/embedding_providers_api.rs
+++ b/src/apis/embedding_providers_api.rs
@@ -84,7 +84,11 @@ pub async fn create_embedding_provider(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -148,7 +152,11 @@ pub async fn delete_embedding_provider(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -198,7 +206,11 @@ pub async fn get_embedding_provider(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -253,7 +265,11 @@ pub async fn list_embedding_providers(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -318,7 +334,11 @@ pub async fn update_embedding_provider(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/indexes_api.rs
+++ b/src/apis/indexes_api.rs
@@ -122,7 +122,11 @@ pub async fn create_dataset_index(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -196,7 +200,11 @@ pub async fn create_index(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -272,7 +280,11 @@ pub async fn delete_dataset_index(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -334,7 +346,11 @@ pub async fn delete_index(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -393,7 +409,11 @@ pub async fn list_dataset_indexes(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -462,7 +482,11 @@ pub async fn list_indexes(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -552,7 +576,11 @@ pub async fn list_indexes_collection(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/information_schema_api.rs
+++ b/src/apis/information_schema_api.rs
@@ -77,7 +77,11 @@ pub async fn information_schema(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/jobs_api.rs
+++ b/src/apis/jobs_api.rs
@@ -60,7 +60,11 @@ pub async fn get_job(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -137,7 +141,11 @@ pub async fn list_jobs(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/query_api.rs
+++ b/src/apis/query_api.rs
@@ -68,7 +68,11 @@ pub async fn query(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/query_runs_api.rs
+++ b/src/apis/query_runs_api.rs
@@ -60,7 +60,11 @@ pub async fn get_query_run(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -136,7 +140,11 @@ pub async fn list_query_runs(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/refresh_api.rs
+++ b/src/apis/refresh_api.rs
@@ -53,7 +53,11 @@ pub async fn refresh(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/results_api.rs
+++ b/src/apis/results_api.rs
@@ -85,7 +85,11 @@ pub async fn get_result(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -159,7 +163,11 @@ pub async fn list_results(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/saved_queries_api.rs
+++ b/src/apis/saved_queries_api.rs
@@ -101,7 +101,11 @@ pub async fn create_saved_query(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -165,7 +169,11 @@ pub async fn delete_saved_query(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -224,7 +232,11 @@ pub async fn execute_saved_query(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -286,7 +298,11 @@ pub async fn get_saved_query(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -352,7 +368,11 @@ pub async fn list_saved_queries(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -424,7 +444,11 @@ pub async fn list_saved_query_versions(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -490,7 +514,11 @@ pub async fn update_saved_query(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/secrets_api.rs
+++ b/src/apis/secrets_api.rs
@@ -83,7 +83,11 @@ pub async fn create_secret(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -147,7 +151,11 @@ pub async fn delete_secret(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -198,7 +206,11 @@ pub async fn get_secret(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -253,7 +265,11 @@ pub async fn list_secrets(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -318,7 +334,11 @@ pub async fn update_secret(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/uploads_api.rs
+++ b/src/apis/uploads_api.rs
@@ -60,7 +60,11 @@ pub async fn list_uploads(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -124,7 +128,11 @@ pub async fn upload_file(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/apis/workspaces_api.rs
+++ b/src/apis/workspaces_api.rs
@@ -68,7 +68,11 @@ pub async fn create_workspace(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -125,7 +129,11 @@ pub async fn delete_workspace(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);
@@ -167,7 +175,11 @@ pub async fn list_workspaces(
 
     let req = req_builder.build()?;
     crate::http_log::log_request(&req);
-    let resp = configuration.client.execute(req).await?;
+    // Route through the shared retry helper so HTTP 429 (OVERLOADED admission
+    // shedding) is retried per `configuration.retry` on every generated op, not
+    // just the hand-written query path. See crate::http::execute_retrying.
+    let resp =
+        crate::http::execute_retrying(&configuration.client, req, &configuration.retry).await?;
 
     let status = resp.status();
     crate::http_log::log_response_status(status);

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,237 @@
+//! Shared HTTP retry helpers for the Hotdata Rust SDK.
+//!
+//! HTTP 429 (`OVERLOADED`) admission-shedding can hit any endpoint, not just
+//! `POST /v1/query`: under concurrent load the server may shed a request with
+//! HTTP 429 + `Retry-After` before it executes server-side. This module owns the
+//! single retry implementation both paths use:
+//!
+//! * the generated free functions in `apis::*` (via the `api.mustache` template,
+//!   which routes every op's `client.execute(req)` through [`execute_retrying`]),
+//!   governed by [`Configuration::retry`](crate::apis::configuration::Configuration::retry);
+//! * the hand-written enhanced query in [`crate::query`], which builds its own
+//!   request to read the `Retry-After` header and reuses the [`backoff_delay`] /
+//!   [`parse_retry_after`] / [`retry_after_secs`] primitives here so the two
+//!   paths never drift.
+//!
+//! 429 retry on a POST is safe here: admission shedding happens before the
+//! request executes, and the request bodies this SDK sends are buffered JSON that
+//! [`reqwest::Request::try_clone`] clones cleanly. A non-clonable (streaming) body
+//! degrades to a single attempt.
+//!
+//! This module is hand-written and listed in `.openapi-generator-ignore`, so it
+//! survives client regeneration.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use reqwest::StatusCode;
+
+use crate::query::RetryPolicy;
+
+/// HTTP 429: admission shedding (too many concurrent requests). Retry keys off
+/// the status code since 429 is unambiguous and the body is not always parsed.
+const HTTP_TOO_MANY_REQUESTS: StatusCode = StatusCode::TOO_MANY_REQUESTS;
+
+/// Execute `req`, retrying on HTTP 429 (OVERLOADED admission-shedding) per
+/// `retry`: honor `Retry-After` when present, else bounded exponential backoff
+/// with jitter, capped at `retry.max_retries`. The request is cloned per
+/// attempt; a non-clonable (streaming) body degrades to a single attempt.
+pub(crate) async fn execute_retrying(
+    client: &reqwest::Client,
+    req: reqwest::Request,
+    retry: &RetryPolicy,
+) -> reqwest::Result<reqwest::Response> {
+    // attempt 0 is the initial request; 1..=max_retries are the retries.
+    for attempt in 0..=retry.max_retries {
+        // Clone the request before consuming it so a 429 can be retried. A
+        // streaming body can't be cloned (`None`) — send it once with no retry.
+        let Some(clone) = req.try_clone() else {
+            return client.execute(req).await;
+        };
+        let resp = client.execute(clone).await?;
+        if resp.status() != HTTP_TOO_MANY_REQUESTS || attempt == retry.max_retries {
+            return Ok(resp);
+        }
+        // HTTP 429 OVERLOADED with attempts remaining: honor Retry-After when
+        // present, else bounded exponential backoff with jitter.
+        let delay = backoff_delay(retry, attempt + 1, parse_retry_after(&resp));
+        tokio::time::sleep(delay).await;
+    }
+    // Unreachable: the loop always returns on its last iteration (attempt ==
+    // max_retries short-circuits above). Send once as a defensive fallback.
+    client.execute(req).await
+}
+
+/// Delay before the next 429 retry: honor `Retry-After` when present (exactly,
+/// uncapped, plus additive jitter so it is never below the server's value),
+/// else bounded exponential backoff with jitter.
+pub(crate) fn backoff_delay(
+    retry: &RetryPolicy,
+    attempt: u32,
+    retry_after: Option<Duration>,
+) -> Duration {
+    if let Some(ra) = retry_after {
+        // The server told us exactly how long to wait — honor it. Add jitter on
+        // top (never below) to desync retries onto the freed slot, and do NOT
+        // cap with max_backoff: capping would dishonor a Retry-After larger than
+        // the cap. The overall deadline budget is the only bound.
+        return ra + ra.mul_f64(retry.jitter * jitter_fraction());
+    }
+    let factor = 2f64.powi(attempt.saturating_sub(1) as i32);
+    let base = retry.base_backoff.mul_f64(factor);
+    let with_jitter = base.mul_f64(1.0 + retry.jitter * jitter_fraction());
+    with_jitter.min(retry.max_backoff)
+}
+
+/// A pseudo-random fraction in `[0, 1)` for jitter. Derived from the wall clock
+/// (no `rand` dependency); when `RetryPolicy::jitter` is 0 this value is
+/// multiplied out, so timing is fully deterministic for tests.
+fn jitter_fraction() -> f64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(d) => (d.subsec_nanos() % 1_000) as f64 / 1_000.0,
+        Err(_) => 0.0,
+    }
+}
+
+/// Parse `Retry-After` (integer/float seconds form) into a [`Duration`]. The
+/// HTTP-date form is not emitted by this API, so it is intentionally ignored.
+pub(crate) fn parse_retry_after(resp: &reqwest::Response) -> Option<Duration> {
+    resp.headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(retry_after_secs)
+}
+
+/// Parse a `Retry-After` header value (seconds form) into a [`Duration`].
+///
+/// Uses the fallible [`Duration::try_from_secs_f64`], which rejects negative,
+/// non-finite (`inf`/`nan`), and overflowing values uniformly — so a malformed
+/// or hostile server-supplied header degrades to normal backoff instead of
+/// panicking inside the async retry path (`from_secs_f64` would panic on
+/// `"inf"` or an overflowing value like `"1e30"`).
+pub(crate) fn retry_after_secs(value: &str) -> Option<Duration> {
+    let secs = value.trim().parse::<f64>().ok()?;
+    Duration::try_from_secs_f64(secs).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// A fast, deterministic retry policy: tiny backoffs, no jitter.
+    fn fast_retry(max_retries: u32) -> RetryPolicy {
+        RetryPolicy {
+            max_retries,
+            base_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(5),
+            deadline: Duration::from_secs(30),
+            jitter: 0.0,
+        }
+    }
+
+    fn post_req(client: &reqwest::Client, url: &str) -> reqwest::Request {
+        client
+            .post(url)
+            .json(&json!({"k": "v"}))
+            .build()
+            .expect("request should build")
+    }
+
+    #[tokio::test]
+    async fn retries_two_429s_then_succeeds() {
+        let server = MockServer::start().await;
+        // Two 429s with Retry-After: 0, then a 200.
+        Mock::given(method("POST"))
+            .and(path("/thing"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+            .up_to_n_times(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/thing"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/thing", server.uri());
+        let resp = execute_retrying(&client, post_req(&client, &url), &fast_retry(5))
+            .await
+            .expect("should succeed after retries");
+        assert_eq!(resp.status(), StatusCode::OK);
+        // 2 retried 429s + 1 success = 3 requests reached the server.
+        assert_eq!(server.received_requests().await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn exhausts_after_max_retries() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/thing"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/thing", server.uri());
+        // 1 initial + 2 retries = 3 requests, all 429; the final 429 is returned.
+        let resp = execute_retrying(&client, post_req(&client, &url), &fast_retry(2))
+            .await
+            .expect("should return the final 429, not a transport error");
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(server.received_requests().await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn non_429_is_returned_without_retry() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/thing"))
+            .respond_with(ResponseTemplate::new(400))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/thing", server.uri());
+        let resp = execute_retrying(&client, post_req(&client, &url), &fast_retry(5))
+            .await
+            .expect("should return the 400 without retrying");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn retry_after_secs_parses_and_rejects_malformed() {
+        assert_eq!(retry_after_secs("2"), Some(Duration::from_secs(2)));
+        assert_eq!(retry_after_secs(" 1.5 "), Some(Duration::from_secs_f64(1.5)));
+        assert_eq!(retry_after_secs("0"), Some(Duration::ZERO));
+        // Malformed / hostile values must degrade to None, never panic.
+        assert_eq!(retry_after_secs("inf"), None);
+        assert_eq!(retry_after_secs("nan"), None);
+        assert_eq!(retry_after_secs("1e30"), None);
+        assert_eq!(retry_after_secs("-5"), None);
+        assert_eq!(retry_after_secs("abc"), None);
+        assert_eq!(retry_after_secs(""), None);
+    }
+
+    #[test]
+    fn backoff_honors_retry_after_and_is_exponential() {
+        let retry = RetryPolicy {
+            base_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(100),
+            jitter: 0.0,
+            ..RetryPolicy::default()
+        };
+        // Retry-After honored exactly with jitter 0.
+        assert_eq!(
+            backoff_delay(&retry, 1, Some(Duration::from_secs(7))),
+            Duration::from_secs(7)
+        );
+        // Otherwise exponential.
+        assert_eq!(backoff_delay(&retry, 1, None), Duration::from_secs(1));
+        assert_eq!(backoff_delay(&retry, 2, None), Duration::from_secs(2));
+        assert_eq!(backoff_delay(&retry, 3, None), Duration::from_secs(4));
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -21,7 +21,7 @@
 //! This module is hand-written and listed in `.openapi-generator-ignore`, so it
 //! survives client regeneration.
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use reqwest::StatusCode;
 
@@ -33,13 +33,21 @@ const HTTP_TOO_MANY_REQUESTS: StatusCode = StatusCode::TOO_MANY_REQUESTS;
 
 /// Execute `req`, retrying on HTTP 429 (OVERLOADED admission-shedding) per
 /// `retry`: honor `Retry-After` when present, else bounded exponential backoff
-/// with jitter, capped at `retry.max_retries`. The request is cloned per
-/// attempt; a non-clonable (streaming) body degrades to a single attempt.
+/// with jitter. Retries stop at `retry.max_retries` OR once the overall
+/// `retry.deadline` budget would be exceeded — whichever comes first. The
+/// request is cloned per attempt; a non-clonable (streaming) body degrades to a
+/// single attempt.
+///
+/// When the budget or retry count is exhausted the last response (the 429) is
+/// returned so the op's normal error mapping surfaces it to the caller — no new
+/// error type. This mirrors `crate::query::submit_with_retry`, which enforces
+/// the same `deadline` on the hand-written query path, so the two stay aligned.
 pub(crate) async fn execute_retrying(
     client: &reqwest::Client,
     req: reqwest::Request,
     retry: &RetryPolicy,
 ) -> reqwest::Result<reqwest::Response> {
+    let start = Instant::now();
     // attempt 0 is the initial request; 1..=max_retries are the retries.
     for attempt in 0..=retry.max_retries {
         // Clone the request before consuming it so a 429 can be retried. A
@@ -54,6 +62,13 @@ pub(crate) async fn execute_retrying(
         // HTTP 429 OVERLOADED with attempts remaining: honor Retry-After when
         // present, else bounded exponential backoff with jitter.
         let delay = backoff_delay(retry, attempt + 1, parse_retry_after(&resp));
+        // Stop if the deadline budget is already spent or this delay would push
+        // total elapsed past it — max_backoff intentionally does not cap an
+        // honored Retry-After, so the deadline is its only bound. Return the
+        // 429 rather than sleeping past the budget.
+        if start.elapsed() + delay > retry.deadline {
+            return Ok(resp);
+        }
         tokio::time::sleep(delay).await;
     }
     // Unreachable: the loop always returns on its last iteration (attempt ==
@@ -182,6 +197,37 @@ mod tests {
             .expect("should return the final 429, not a transport error");
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(server.received_requests().await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn deadline_stops_retries_before_max_retries() {
+        let server = MockServer::start().await;
+        // Every response is a 429 with a Retry-After far larger than the budget.
+        // max_backoff intentionally does NOT cap Retry-After, so only the
+        // deadline can stop the loop — and it must, before max_retries is hit.
+        Mock::given(method("POST"))
+            .and(path("/thing"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "100"))
+            .mount(&server)
+            .await;
+
+        let retry = RetryPolicy {
+            max_retries: 10,
+            base_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_secs(1),
+            // Tiny budget: the first 100s Retry-After overshoots it immediately.
+            deadline: Duration::from_millis(10),
+            jitter: 0.0,
+        };
+        let client = reqwest::Client::new();
+        let url = format!("{}/thing", server.uri());
+        let resp = execute_retrying(&client, post_req(&client, &url), &retry)
+            .await
+            .expect("should return the 429 after the deadline stops retries");
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        // The deadline stops retries after the very first 429 — well before the
+        // 10 max_retries — so only one request reaches the server.
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod arrow;
 pub mod auth;
 pub mod client;
 pub mod field;
+pub(crate) mod http;
 pub mod http_log;
 pub mod models;
 pub mod query;

--- a/src/query.rs
+++ b/src/query.rs
@@ -52,12 +52,13 @@
 // accept clippy's large-Err lint for this module.
 #![allow(clippy::result_large_err)]
 
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::apis::configuration::Configuration;
+use crate::http::{backoff_delay, parse_retry_after};
 use crate::apis::query_api::QueryError as GeneratedQueryError;
 use crate::apis::results_api::GetResultError;
 use crate::apis::{query_runs_api, results_api, Error, ResponseContent};
@@ -565,33 +566,6 @@ fn overloaded(attempts: u32, raw: RawResponse) -> QueryError {
     }
 }
 
-/// Delay before the next 429 retry: honor `Retry-After` when present (exactly,
-/// uncapped, plus additive jitter so it is never below the server's value),
-/// else bounded exponential backoff with jitter.
-fn backoff_delay(retry: &RetryPolicy, attempt: u32, retry_after: Option<Duration>) -> Duration {
-    if let Some(ra) = retry_after {
-        // The server told us exactly how long to wait — honor it. Add jitter on
-        // top (never below) to desync retries onto the freed slot, and do NOT
-        // cap with max_backoff: capping would dishonor a Retry-After larger than
-        // the cap. The overall deadline budget is the only bound.
-        return ra + ra.mul_f64(retry.jitter * jitter_fraction());
-    }
-    let factor = 2f64.powi(attempt.saturating_sub(1) as i32);
-    let base = retry.base_backoff.mul_f64(factor);
-    let with_jitter = base.mul_f64(1.0 + retry.jitter * jitter_fraction());
-    with_jitter.min(retry.max_backoff)
-}
-
-/// A pseudo-random fraction in `[0, 1)` for jitter. Derived from the wall clock
-/// (no `rand` dependency); when `RetryPolicy::jitter` is 0 this value is
-/// multiplied out, so timing is fully deterministic for tests.
-fn jitter_fraction() -> f64 {
-    match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(d) => (d.subsec_nanos() % 1_000) as f64 / 1_000.0,
-        Err(_) => 0.0,
-    }
-}
-
 /// Build and send one `POST /v1/query`, returning the status, parsed
 /// `Retry-After`, and body. Mirrors the generated op's request construction.
 async fn send_query(
@@ -646,27 +620,6 @@ fn apply_apikey_headers(
         }
     }
     req_builder
-}
-
-/// Parse `Retry-After` (integer/float seconds form) into a [`Duration`]. The
-/// HTTP-date form is not emitted by this API, so it is intentionally ignored.
-fn parse_retry_after(resp: &reqwest::Response) -> Option<Duration> {
-    resp.headers()
-        .get(reqwest::header::RETRY_AFTER)
-        .and_then(|v| v.to_str().ok())
-        .and_then(retry_after_secs)
-}
-
-/// Parse a `Retry-After` header value (seconds form) into a [`Duration`].
-///
-/// Uses the fallible [`Duration::try_from_secs_f64`], which rejects negative,
-/// non-finite (`inf`/`nan`), and overflowing values uniformly — so a malformed
-/// or hostile server-supplied header degrades to normal backoff instead of
-/// panicking inside the async retry path (`from_secs_f64` would panic on
-/// `"inf"` or an overflowing value like `"1e30"`).
-fn retry_after_secs(value: &str) -> Option<Duration> {
-    let secs = value.trim().parse::<f64>().ok()?;
-    Duration::try_from_secs_f64(secs).ok()
 }
 
 /// Poll `GET /v1/results/{id}` until the result is `ready`, returning the ready
@@ -1541,23 +1494,6 @@ mod tests {
         let big = estimate_rows_bytes(&[vec![json!("aaaaaaaaaa")]]);
         assert!(small > 0);
         assert!(big > small);
-    }
-
-    #[test]
-    fn retry_after_secs_parses_and_rejects_malformed() {
-        // Valid seconds forms.
-        assert_eq!(retry_after_secs("2"), Some(Duration::from_secs(2)));
-        assert_eq!(retry_after_secs(" 1.5 "), Some(Duration::from_secs_f64(1.5)));
-        assert_eq!(retry_after_secs("0"), Some(Duration::ZERO));
-        // Malformed / hostile server-supplied values must degrade to None, never
-        // panic: `inf` and an overflowing `1e30` both panic `from_secs_f64` (the
-        // prior impl), and the old `>= 0.0` filter let `inf` through.
-        assert_eq!(retry_after_secs("inf"), None);
-        assert_eq!(retry_after_secs("nan"), None);
-        assert_eq!(retry_after_secs("1e30"), None);
-        assert_eq!(retry_after_secs("-5"), None);
-        assert_eq!(retry_after_secs("abc"), None);
-        assert_eq!(retry_after_secs(""), None);
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -35,7 +35,7 @@
 //! | [`query_with`](crate::Client::query_with) | Per-call control: a custom [`QueryConfig`] (and optional database scope). |
 //! | [`submit_query`](crate::Client::submit_query) | Asynchronous submission (`async = true`): returns an acknowledgement to poll. |
 //! | [`query_to_arrow`](crate::Client::query_to_arrow) | Run a query and fetch its persisted result as Arrow in one call. |
-//! | `client.queries().execute()` / [`apis::query_api::query`](crate::apis::query_api::query) | The raw generated op, without retry or auto-follow. |
+//! | `client.queries().execute()` / [`apis::query_api::query`](crate::apis::query_api::query) | The raw generated op: 429 retry applies (per `Configuration::retry`), but without auto-follow. |
 //!
 //! Instance defaults come from [`ClientBuilder::query_config`](crate::ClientBuilder::query_config);
 //! tweak one for a single call by chaining [`QueryConfig`]'s `with_*` setters off


### PR DESCRIPTION
Routes every generated API op's request through a shared `execute_retrying` helper so HTTP 429 (`OVERLOADED` admission-shedding) is retried per `Configuration.retry` — honoring `Retry-After`, exponential backoff with jitter, `max_retries`, and the overall `deadline` budget — not just the hand-written query path. The change lives in the mustache template, so it survives regeneration.