### PR TITLE
chore: release hotdata v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.3.0] - 2026-06-16
+
 ### Added
 
 - Every generated `apis::*` operation now transparently retries HTTP 429

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Every generated `apis::*` operation now transparently retries HTTP 429
+  (`OVERLOADED`) admission shedding, honoring `Retry-After` with backoff before
+  the op returns (#58). The policy is the new `Configuration::retry` field
+  (`crate::query::RetryPolicy`, defaulting to `RetryPolicy::default`); set
+  `max_retries` to 0 to disable. The enhanced query path (`crate::query`) keeps
+  using its own per-call `QueryConfig::retry` instead.
 
 ## [0.2.0] - 2026-06-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"


### PR DESCRIPTION
Release **hotdata v0.3.0**: version bumped in `Cargo.toml` and `CHANGELOG.md` updated. After merge, run `./scripts/release.sh publish` from a clean `main` checkout.