### PR TITLE
chore: release hotdata v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
-- chore: remove datasets API and related job types
+- **Breaking:** the datasets API and all related types, following their removal
+  from the Hotdata OpenAPI spec. This drops the `datasets_api` module and the
+  `client.datasets()` resource handle; every dataset model
+  (`CreateDatasetRequest`/`CreateDatasetResponse`, `GetDatasetResponse`,
+  `UpdateDatasetRequest`/`UpdateDatasetResponse`, `ListDatasetsResponse`,
+  `ListDatasetVersionsResponse`, `RefreshDatasetResponse`, `DatasetSummary`,
+  `DatasetVersionSummary`, `DatasetSource` and its `*OneOf*` variants,
+  `InlineDatasetSource`, `SavedQueryDatasetSource`, `SqlQueryDatasetSource`,
+  `UploadDatasetSource`, `UrlDatasetSource`, `InlineData`, `ColumnTypeSpec`);
+  and the dataset-related `JobType` variants (`DatasetRefresh`,
+  `CreateDatasetIndex`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.4.0] - 2026-06-19
+
 ### Removed
 
 - **Breaking:** the datasets API and all related types, following their removal
@@ -31,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hand-written `Client::query` / `Client::submit_query` paths, governed by the
   same `RetryPolicy` budget as 429. Response-phase transport errors are left
   un-retried so a non-idempotent `POST` can't double-execute (#63).
-
 
 ## [0.3.2] - 2026-06-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"

--- a/src/apis/configuration.rs
+++ b/src/apis/configuration.rs
@@ -71,7 +71,7 @@ impl Default for Configuration {
     fn default() -> Self {
         Configuration {
             base_path: "https://api.hotdata.dev".to_owned(),
-            user_agent: Some("hotdata-rust/0.3.2".to_owned()),
+            user_agent: Some("hotdata-rust/0.4.0".to_owned()),
             client: reqwest::Client::new(),
             basic_auth: None,
             oauth_access_token: None,


### PR DESCRIPTION
Release **hotdata v0.4.0**: version bumped in `Cargo.toml` and `CHANGELOG.md` updated. After merge, run `./scripts/release.sh publish` from a clean `main` checkout.