### PR TITLE
feat(uploads): stream large files with just-in-time part minting

### DIFF
--- a/src/uploads.rs
+++ b/src/uploads.rs
@@ -5,14 +5,20 @@
 //! presigned-upload flow that the generated [`apis::uploads_api`](crate::apis::uploads_api)
 //! ops expose as raw building blocks:
 //!
-//! 1. `POST /v1/uploads` ([`create_upload_session_handler`]) opens a session and
-//!    returns either a single `url` (`mode == "single"`) or a set of `part_urls`
-//!    plus a `part_size` (`mode == "multipart"`), along with a one-time
-//!    `finalize_token`.
+//! 1. `POST /v1/uploads` ([`create_upload_session_handler`]) opens a session.
+//!    A small file declares its size and gets a single `url` (`mode == "single"`)
+//!    or, for a known-size multipart upload, a full set of `part_urls` plus a
+//!    `part_size` (`mode == "multipart"`). A large file omits its declared size
+//!    to open a **streaming** session: `mode == "multipart"` with a `part_size`
+//!    but NO `part_urls` — the client mints each part URL on demand from
+//!    `POST /v1/uploads/{id}/parts` ([`mint_upload_parts_handler`]) just before
+//!    uploading that part, so a URL can't expire mid-transfer on a slow upload.
+//!    Every session also carries a one-time `finalize_token`.
 //! 2. The client `PUT`s the bytes **directly to object storage** — never back
 //!    through the API. Single uploads stream the whole file to `url`; multipart
 //!    uploads slice the file into `part_size`-byte chunks and `PUT` each chunk to
-//!    its `part_urls[i - 1]`, collecting the storage `ETag` per part.
+//!    its part URL (pre-issued for known-size, minted on demand for streaming),
+//!    collecting the storage `ETag` per part.
 //! 3. `POST /v1/uploads/{upload_id}/finalize` ([`finalize_upload_handler`])
 //!    confirms the upload with the finalize token in the `X-Upload-Finalize-Token`
 //!    header (empty body for single; the ascending `{part_number, e_tag}` list
@@ -66,6 +72,12 @@ pub const MIN_PART_SIZE: u64 = 5 * MIB;
 /// Maximum part size storage accepts (5 GiB). The hint is clamped to at most
 /// this.
 pub const MAX_PART_SIZE: u64 = 5 * 1024 * MIB;
+
+/// Maximum number of part numbers to request in a single on-demand mint call
+/// (`POST /v1/uploads/{id}/parts`). The server caps a batch at this, so the
+/// streaming uploader mints in batches no larger than this, kept just ahead of
+/// the parts it is about to upload.
+pub const MAX_MINT_BATCH: usize = 100;
 
 /// Target peak-memory budget for in-flight part buffers (256 MiB). Each
 /// in-flight part buffers up to `part_size` bytes, so [`effective_in_flight`]
@@ -219,6 +231,9 @@ pub enum UploadError {
     },
     /// Finalizing the upload (`POST /v1/uploads/{id}/finalize`) failed.
     Finalize(Error<apis::uploads_api::FinalizeUploadHandlerError>),
+    /// Minting part URLs on demand (`POST /v1/uploads/{id}/parts`) failed during
+    /// a streaming upload — either the initial batch or an on-403 re-mint.
+    MintParts(Error<apis::uploads_api::MintUploadPartsHandlerError>),
 }
 
 impl std::fmt::Display for UploadError {
@@ -252,6 +267,7 @@ impl std::fmt::Display for UploadError {
                 write!(f, "malformed upload session response: {msg}")
             }
             UploadError::Finalize(e) => write!(f, "finalizing the upload failed: {e}"),
+            UploadError::MintParts(e) => write!(f, "minting upload part URLs failed: {e}"),
         }
     }
 }
@@ -263,6 +279,7 @@ impl std::error::Error for UploadError {
             UploadError::CreateSession(e) => Some(e),
             UploadError::Storage(e) => Some(e),
             UploadError::Finalize(e) => Some(e),
+            UploadError::MintParts(e) => Some(e),
             _ => None,
         }
     }
@@ -310,16 +327,26 @@ pub(crate) async fn upload_file(
             value: part_size_hint,
         })?;
 
-    // Open the session. `declared_size_bytes` (the exact byte count finalize
-    // validates against) is sent explicitly, which keeps the session in
-    // known-size mode; the struct-update base fills the optional checksum
-    // fields with None.
+    // Default a large file to a JUST-IN-TIME (streaming) session: omit
+    // `declared_size_bytes` so the server mints NO part URLs up front. The client
+    // then mints each part URL moments before it uploads that part (see
+    // `upload_multipart_streaming`), so a URL cannot expire mid-transfer no
+    // matter how long a slow upload runs — the failure mode of the eager
+    // known-size path, whose URLs share a ~30-minute TTL. A small file is a
+    // single quick `PUT` with no expiry risk, so it keeps the known-size path
+    // (and the server's single-`PUT` fast path) by declaring its size. The
+    // struct-update base fills the optional checksum fields with None.
+    let stream = total > DEFAULT_PART_SIZE;
     let create = models::CreateUploadRequest {
         content_type: opts.content_type.clone().map(Some),
         content_encoding: opts.content_encoding.clone().map(Some),
         filename: filename.map(Some),
         part_size: Some(Some(part_size_hint_i64)),
-        declared_size_bytes: Some(Some(declared_size_bytes)),
+        declared_size_bytes: if stream {
+            None
+        } else {
+            Some(Some(declared_size_bytes))
+        },
         ..models::CreateUploadRequest::new()
     };
     let session = apis::uploads_api::create_upload_session_handler(configuration, create)
@@ -339,7 +366,12 @@ pub(crate) async fn upload_file(
         }
         "multipart" => {
             let max_concurrency = opts.max_concurrency.unwrap_or(DEFAULT_MAX_CONCURRENCY);
-            Some(
+            // A streaming (unknown-size) session returns NO part URLs up front
+            // (the `part_urls` key is absent or null) — mint them on demand. A
+            // known-size session returns the full `part_urls` list to PUT to
+            // directly. An explicitly present (even empty) list is a known-size
+            // response; `upload_multipart` validates it and rejects an empty one.
+            let parts = if matches!(session.part_urls, Some(Some(_))) {
                 upload_multipart(
                     configuration,
                     &session,
@@ -348,8 +380,19 @@ pub(crate) async fn upload_file(
                     max_concurrency,
                     opts.progress.as_ref(),
                 )
-                .await?,
-            )
+                .await?
+            } else {
+                upload_multipart_streaming(
+                    configuration,
+                    &session,
+                    path,
+                    total,
+                    max_concurrency,
+                    opts.progress.as_ref(),
+                )
+                .await?
+            };
+            Some(parts)
         }
         other => {
             return Err(UploadError::MalformedSession(format!(
@@ -625,6 +668,189 @@ async fn upload_multipart(
 
     // `results` is indexed by 0-based part position, so collecting it in order
     // yields parts ascending by part_number with no duplicates.
+    Ok(results.into_iter().flatten().collect())
+}
+
+/// Streaming (just-in-time) multipart path: the session was opened WITHOUT a
+/// declared size, so the server minted no part URLs up front. We still know the
+/// local file's size, so the part count is fixed by the server's echoed
+/// `part_size`; we mint URLs on demand — in batches of at most [`MAX_MINT_BATCH`]
+/// kept just ahead of upload progress — and `PUT` each part with bounded
+/// concurrency.
+///
+/// If a part `PUT` is rejected with `403` (an expired presigned URL / S3
+/// `SignatureDoesNotMatch`), that single part is re-minted and the `PUT` retried
+/// once: the part number and underlying upload are unchanged, so storage simply
+/// overwrites that part. This is what lets a slow upload outlive a minted URL's
+/// TTL and still complete.
+///
+/// Returns the parts sorted ascending by part number, ready for finalize.
+async fn upload_multipart_streaming(
+    configuration: &Configuration,
+    session: &models::UploadSessionResponse,
+    path: &Path,
+    total: u64,
+    max_concurrency: usize,
+    progress: Option<&UploadProgress>,
+) -> Result<Vec<models::FinalizeUploadPart>, UploadError> {
+    let part_size = session.part_size.flatten().ok_or_else(|| {
+        UploadError::MalformedSession("streaming upload missing `part_size`".to_owned())
+    })?;
+    if part_size <= 0 {
+        return Err(UploadError::MalformedSession(format!(
+            "streaming upload has non-positive `part_size` {part_size}"
+        )));
+    }
+    let part_size = part_size as u64;
+
+    // Slice by the SERVER's echoed part size (never our hint); the last part is
+    // the remainder. We know the file size, so the part count is fixed up front
+    // even though the server does not.
+    let expected_parts = total.div_ceil(part_size).max(1) as usize;
+
+    // Peak buffered memory is in_flight * part_size; bound in-flight by both the
+    // caller's max_concurrency and the memory budget (same as the eager path).
+    let in_flight_cap = effective_in_flight(max_concurrency, part_size);
+
+    // Aggregate progress across parts via a shared counter.
+    let done = Arc::new(AtomicU64::new(0));
+    let mut results: Vec<Option<models::FinalizeUploadPart>> = vec![None; expected_parts];
+
+    // Shared by the proactive minting below AND each part task's on-403 re-mint.
+    // `reqwest::Client` clones cheaply (Arc inside), so cloning the config is fine.
+    let config = Arc::new(configuration.clone());
+    let upload_id = session.upload_id.clone();
+    let finalize_token = session.finalize_token.clone();
+
+    // Minted-but-not-yet-uploaded part URLs, ascending by part number. Refilled
+    // from POST /parts as it drains so a URL is minted shortly before its `PUT`.
+    let mut minted: std::collections::VecDeque<models::MintedUploadPartResponse> =
+        std::collections::VecDeque::new();
+    let mut next_to_mint = 1i32; // next 1-based part number to request a URL for
+    let mut next_index = 0usize; // next 0-based part to spawn a `PUT` for
+
+    let mut join_set: tokio::task::JoinSet<
+        Result<(usize, models::FinalizeUploadPart), UploadError>,
+    > = tokio::task::JoinSet::new();
+
+    loop {
+        while join_set.len() < in_flight_cap && next_index < expected_parts {
+            // Keep the buffer at least one in-flight window ahead, minting in
+            // batches capped at the server's per-call limit.
+            if minted.len() < in_flight_cap && (next_to_mint as usize) <= expected_parts {
+                let lo = next_to_mint;
+                let hi = (lo as usize + MAX_MINT_BATCH - 1).min(expected_parts) as i32;
+                let part_numbers: Vec<i32> = (lo..=hi).collect();
+                let resp = apis::uploads_api::mint_upload_parts_handler(
+                    &config,
+                    &upload_id,
+                    &finalize_token,
+                    models::MintUploadPartsRequest::new(part_numbers),
+                )
+                .await
+                .map_err(UploadError::MintParts)?;
+                for p in resp.parts {
+                    minted.push_back(p);
+                }
+                next_to_mint = hi + 1;
+            }
+
+            let minted_part = minted.pop_front().ok_or_else(|| {
+                UploadError::MalformedSession(
+                    "streaming mint returned no URL for a pending part".to_owned(),
+                )
+            })?;
+            let part_number = minted_part.part_number;
+            let url = minted_part.url;
+            let index = next_index;
+            next_index += 1;
+
+            let offset = index as u64 * part_size;
+            let len = part_size.min(total.saturating_sub(offset));
+
+            let headers = session.headers.clone();
+            let done = Arc::clone(&done);
+            let progress = progress.cloned();
+            let retry = configuration.retry;
+            let path = path.to_path_buf();
+            let config = Arc::clone(&config);
+            let upload_id = upload_id.clone();
+            let finalize_token = finalize_token.clone();
+
+            join_set.spawn(async move {
+                let chunk = read_range(&path, offset, len).await?;
+                let resp =
+                    match put_to_storage(&retry, &url, &headers, chunk, len, Some(part_number))
+                        .await
+                    {
+                        // An expired presigned URL surfaces as 403. Re-mint this
+                        // one part and retry the `PUT` once.
+                        Err(UploadError::StorageStatus { status, .. })
+                            if status == reqwest::StatusCode::FORBIDDEN =>
+                        {
+                            let remint = apis::uploads_api::mint_upload_parts_handler(
+                                &config,
+                                &upload_id,
+                                &finalize_token,
+                                models::MintUploadPartsRequest::new(vec![part_number]),
+                            )
+                            .await
+                            .map_err(UploadError::MintParts)?;
+                            let fresh = remint
+                                .parts
+                                .into_iter()
+                                .find(|p| p.part_number == part_number)
+                                .ok_or_else(|| {
+                                    UploadError::MalformedSession(format!(
+                                        "re-mint returned no URL for part {part_number}"
+                                    ))
+                                })?;
+                            let chunk = read_range(&path, offset, len).await?;
+                            put_to_storage(
+                                &retry,
+                                &fresh.url,
+                                &headers,
+                                chunk,
+                                len,
+                                Some(part_number),
+                            )
+                            .await?
+                        }
+                        other => other?,
+                    };
+
+                let e_tag = resp
+                    .headers()
+                    .get(reqwest::header::ETAG)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.to_owned())
+                    .ok_or(UploadError::MissingETag { part_number })?;
+
+                if let Some(progress) = progress.as_ref() {
+                    let now = done.fetch_add(len, Ordering::SeqCst) + len;
+                    progress(now, total);
+                }
+
+                Ok::<_, UploadError>((index, models::FinalizeUploadPart { e_tag, part_number }))
+            });
+        }
+
+        match join_set.join_next().await {
+            Some(Ok(Ok((index, part)))) => results[index] = Some(part),
+            Some(Ok(Err(e))) => {
+                join_set.abort_all();
+                return Err(e);
+            }
+            Some(Err(join_err)) => {
+                join_set.abort_all();
+                return Err(UploadError::Io(std::io::Error::other(format!(
+                    "part upload task failed: {join_err}"
+                ))));
+            }
+            None => break,
+        }
+    }
+
     Ok(results.into_iter().flatten().collect())
 }
 

--- a/src/uploads.rs
+++ b/src/uploads.rs
@@ -79,6 +79,15 @@ pub const MAX_PART_SIZE: u64 = 5 * 1024 * MIB;
 /// the parts it is about to upload.
 pub const MAX_MINT_BATCH: usize = 100;
 
+/// File-size boundary between the two upload strategies. A file at or below this
+/// size takes the known-size path — a single quick `PUT` (or a short eager
+/// multipart) that completes well within a presigned URL's TTL, so there is no
+/// expiry risk. A larger file uses the streaming just-in-time path, minting each
+/// part URL only moments before it is uploaded. Set to [`DEFAULT_PART_SIZE`],
+/// the server's default single-vs-multipart boundary, so small uploads keep the
+/// single-`PUT` fast path unchanged.
+pub const STREAMING_THRESHOLD: u64 = DEFAULT_PART_SIZE;
+
 /// Target peak-memory budget for in-flight part buffers (256 MiB). Each
 /// in-flight part buffers up to `part_size` bytes, so [`effective_in_flight`]
 /// derives the in-flight count as `budget / part_size`.
@@ -315,12 +324,8 @@ pub(crate) async fn upload_file(
     // grow the hint (bounding the part count). The server clamps it regardless.
     let part_size_hint = opts.part_size.unwrap_or_else(|| auto_part_size_hint(total));
 
-    // The wire models size as a signed i64; reject (rather than silently wrap)
-    // a pathological size beyond i64::MAX.
-    let declared_size_bytes = i64::try_from(total).map_err(|_| UploadError::SizeOverflow {
-        what: "declared_size_bytes",
-        value: total,
-    })?;
+    // The wire models the part-size hint as a signed i64; reject (rather than
+    // silently wrap) a pathological hint beyond i64::MAX.
     let part_size_hint_i64 =
         i64::try_from(part_size_hint).map_err(|_| UploadError::SizeOverflow {
             what: "part_size",
@@ -334,19 +339,26 @@ pub(crate) async fn upload_file(
     // matter how long a slow upload runs — the failure mode of the eager
     // known-size path, whose URLs share a ~30-minute TTL. A small file is a
     // single quick `PUT` with no expiry risk, so it keeps the known-size path
-    // (and the server's single-`PUT` fast path) by declaring its size. The
-    // struct-update base fills the optional checksum fields with None.
-    let stream = total > DEFAULT_PART_SIZE;
+    // (and the server's single-`PUT` fast path) by declaring its size.
+    //
+    // `declared_size_bytes` is sent (and so range-checked against the wire's
+    // i64) ONLY on the known-size path; a streaming upload omits it entirely, so
+    // a size beyond i64::MAX is never an obstacle to a streamed file.
+    let declared_size_bytes = if total > STREAMING_THRESHOLD {
+        None
+    } else {
+        let size = i64::try_from(total).map_err(|_| UploadError::SizeOverflow {
+            what: "declared_size_bytes",
+            value: total,
+        })?;
+        Some(Some(size))
+    };
     let create = models::CreateUploadRequest {
         content_type: opts.content_type.clone().map(Some),
         content_encoding: opts.content_encoding.clone().map(Some),
         filename: filename.map(Some),
         part_size: Some(Some(part_size_hint_i64)),
-        declared_size_bytes: if stream {
-            None
-        } else {
-            Some(Some(declared_size_bytes))
-        },
+        declared_size_bytes,
         ..models::CreateUploadRequest::new()
     };
     let session = apis::uploads_api::create_upload_session_handler(configuration, create)
@@ -722,49 +734,71 @@ async fn upload_multipart_streaming(
     let upload_id = session.upload_id.clone();
     let finalize_token = session.finalize_token.clone();
 
-    // Minted-but-not-yet-uploaded part URLs, ascending by part number. Refilled
-    // from POST /parts as it drains so a URL is minted shortly before its `PUT`.
-    let mut minted: std::collections::VecDeque<models::MintedUploadPartResponse> =
-        std::collections::VecDeque::new();
+    // Minted-but-not-yet-uploaded `(part_number, url)` pairs, ascending by part
+    // number. Refilled from POST /parts as it drains so a URL is minted shortly
+    // before its `PUT`.
+    let mut minted: std::collections::VecDeque<(i32, String)> = std::collections::VecDeque::new();
     let mut next_to_mint = 1i32; // next 1-based part number to request a URL for
-    let mut next_index = 0usize; // next 0-based part to spawn a `PUT` for
+    let mut next_part = 1i32; // next 1-based part number to spawn a `PUT` for
 
     let mut join_set: tokio::task::JoinSet<
         Result<(usize, models::FinalizeUploadPart), UploadError>,
     > = tokio::task::JoinSet::new();
 
     loop {
-        while join_set.len() < in_flight_cap && next_index < expected_parts {
+        while join_set.len() < in_flight_cap && (next_part as usize) <= expected_parts {
             // Keep the buffer at least one in-flight window ahead, minting in
             // batches capped at the server's per-call limit.
             if minted.len() < in_flight_cap && (next_to_mint as usize) <= expected_parts {
                 let lo = next_to_mint;
                 let hi = (lo as usize + MAX_MINT_BATCH - 1).min(expected_parts) as i32;
-                let part_numbers: Vec<i32> = (lo..=hi).collect();
                 let resp = apis::uploads_api::mint_upload_parts_handler(
                     &config,
                     &upload_id,
                     &finalize_token,
-                    models::MintUploadPartsRequest::new(part_numbers),
+                    models::MintUploadPartsRequest::new((lo..=hi).collect()),
                 )
                 .await
                 .map_err(UploadError::MintParts)?;
-                for p in resp.parts {
-                    minted.push_back(p);
+                // Pair each URL with the part number the SERVER labelled it,
+                // then enqueue strictly in the order WE requested (lo..=hi).
+                // This catches a missing or unexpected part number here — rather
+                // than letting a mismatch silently shift every later part's byte
+                // offset — and makes the queue order independent of the order the
+                // server happened to list the URLs in.
+                let mut by_number: std::collections::HashMap<i32, String> = resp
+                    .parts
+                    .into_iter()
+                    .map(|p| (p.part_number, p.url))
+                    .collect();
+                for n in lo..=hi {
+                    let url = by_number.remove(&n).ok_or_else(|| {
+                        UploadError::MalformedSession(format!(
+                            "mint did not return a URL for part {n}"
+                        ))
+                    })?;
+                    minted.push_back((n, url));
+                }
+                if !by_number.is_empty() {
+                    return Err(UploadError::MalformedSession(
+                        "mint returned URLs for parts that were not requested".to_owned(),
+                    ));
                 }
                 next_to_mint = hi + 1;
             }
 
-            let minted_part = minted.pop_front().ok_or_else(|| {
+            let (part_number, url) = minted.pop_front().ok_or_else(|| {
                 UploadError::MalformedSession(
                     "streaming mint returned no URL for a pending part".to_owned(),
                 )
             })?;
-            let part_number = minted_part.part_number;
-            let url = minted_part.url;
-            let index = next_index;
-            next_index += 1;
-
+            // Parts are minted and enqueued in ascending order, so the front of
+            // the queue is always `next_part`. Derive the byte range from the
+            // part number itself (not from queue position) so the uploaded slice
+            // and the finalize entry can never disagree.
+            debug_assert_eq!(part_number, next_part);
+            next_part += 1;
+            let index = (part_number - 1) as usize;
             let offset = index as u64 * part_size;
             let len = part_size.min(total.saturating_sub(offset));
 
@@ -851,7 +885,16 @@ async fn upload_multipart_streaming(
         }
     }
 
-    Ok(results.into_iter().flatten().collect())
+    // Every slot must be filled: we spawned exactly one task per part and place
+    // each result by its part index. A `None` would mean a part silently went
+    // unuploaded, so surface it rather than finalizing a short list.
+    let mut parts = Vec::with_capacity(results.len());
+    for (i, slot) in results.into_iter().enumerate() {
+        parts.push(slot.ok_or_else(|| {
+            UploadError::MalformedSession(format!("part {} was never uploaded", i + 1))
+        })?);
+    }
+    Ok(parts)
 }
 
 /// Read exactly `len` bytes starting at `offset` from `path`. A positioned read

--- a/tests/presigned_uploads.rs
+++ b/tests/presigned_uploads.rs
@@ -1645,3 +1645,141 @@ async fn expired_part_url_is_reminted_and_retried() {
         "part 1 must be re-minted after its URL expired, saw {p1_mints} mints for it"
     );
 }
+
+/// The SDK must pair each minted URL with the part number the SERVER labelled it
+/// — not with the order the URLs arrive in — so a response listing parts out of
+/// order still uploads every byte range to the correct part. Here the mint
+/// responder deliberately reverses the parts; each storage part must still
+/// receive its own slice.
+#[tokio::test]
+async fn mint_response_order_does_not_corrupt_part_slices() {
+    let server = MockServer::start().await;
+    let storage_base = server.uri();
+    // 9 MiB over a 4 MiB part size -> 3 parts: 4 MiB, 4 MiB, 1 MiB.
+    let part_size = 4 * MIB;
+    let contents: Vec<u8> = (0..9 * MIB).map(|i| (i % 251) as u8).collect();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "finalize_token": "ftok_ord",
+            "headers": {},
+            "mode": "multipart",
+            "part_size": part_size,
+            "upload_id": "upl_ord",
+        })))
+        .mount(&server)
+        .await;
+
+    // Mint responder that returns the requested parts in REVERSE order.
+    let base = storage_base.clone();
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads/upl_ord/parts"))
+        .respond_with(move |req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            let mut parts: Vec<serde_json::Value> = body["part_numbers"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|n| {
+                    let n = n.as_i64().unwrap();
+                    serde_json::json!({ "part_number": n, "url": format!("{base}/storage/spart/{n}") })
+                })
+                .collect();
+            parts.reverse();
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "parts": parts }))
+        })
+        .mount(&server)
+        .await;
+
+    for n in 1..=3 {
+        Mock::given(method("PUT"))
+            .and(path(format!("/storage/spart/{n}")))
+            .respond_with(ResponseTemplate::new(200).insert_header("ETag", format!("\"etag-{n}\"")))
+            .mount(&server)
+            .await;
+    }
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads/upl_ord/finalize"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(mock_finalize_ok("upl_ord", contents.len())),
+        )
+        .mount(&server)
+        .await;
+
+    let path = temp_file(&contents);
+    let client = test_client(&server.uri());
+    let result = client.upload_file(&path, UploadOptions::default()).await;
+    let _ = std::fs::remove_file(&path);
+    result.expect("out-of-order mint response must not break the upload");
+
+    let requests = server.received_requests().await.expect("requests recorded");
+    let expected = [
+        &contents[0..4 * MIB],
+        &contents[4 * MIB..8 * MIB],
+        &contents[8 * MIB..9 * MIB],
+    ];
+    for (i, slice) in expected.iter().enumerate() {
+        let part_path = format!("/storage/spart/{}", i + 1);
+        let put = requests
+            .iter()
+            .find(|r| r.url.path() == part_path)
+            .unwrap_or_else(|| panic!("a PUT to {part_path} should have been made"));
+        assert_eq!(
+            &put.body[..],
+            *slice,
+            "part {} must receive its own {}-byte slice despite the reversed mint response",
+            i + 1,
+            slice.len()
+        );
+    }
+}
+
+/// If a mint response omits a requested part number, the SDK must fail loudly
+/// (rather than shift later parts' byte offsets), since the byte range for each
+/// part is keyed to its number.
+#[tokio::test]
+async fn mint_missing_requested_part_is_rejected() {
+    let server = MockServer::start().await;
+    let storage_base = server.uri();
+    let part_size = 5 * MIB;
+    let contents: Vec<u8> = (0..9 * MIB).map(|i| (i % 251) as u8).collect(); // 2 parts
+
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "finalize_token": "ftok_miss",
+            "headers": {},
+            "mode": "multipart",
+            "part_size": part_size,
+            "upload_id": "upl_miss",
+        })))
+        .mount(&server)
+        .await;
+
+    // Responder returns ONLY part 1 even when more were requested.
+    let base = storage_base.clone();
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads/upl_miss/parts"))
+        .respond_with(move |_req: &Request| {
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "parts": [{ "part_number": 1, "url": format!("{base}/storage/spart/1") }]
+            }))
+        })
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/storage/spart/\d+$"))
+        .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"e\""))
+        .mount(&server)
+        .await;
+
+    let path = temp_file(&contents);
+    let client = test_client(&server.uri());
+    let result = client.upload_file(&path, UploadOptions::default()).await;
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        matches!(result, Err(UploadError::MalformedSession(_))),
+        "a mint response missing a requested part must be rejected, got {result:?}"
+    );
+}

--- a/tests/presigned_uploads.rs
+++ b/tests/presigned_uploads.rs
@@ -1358,3 +1358,290 @@ async fn serial_when_max_concurrency_is_one() {
         "max_concurrency=1 must keep PUTs strictly serial (no overlap)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Streaming (just-in-time part minting) — issue sdk-rust#76
+// ---------------------------------------------------------------------------
+
+/// One mebibyte.
+const MIB: usize = 1024 * 1024;
+
+/// A wiremock responder for `POST /v1/uploads/{id}/parts` that reads the
+/// requested `part_numbers` from the request body and returns one minted URL per
+/// part, each pointing at `{storage_base}/storage/spart/{n}`. This mirrors the
+/// real server, which mints exactly the parts asked for, on demand.
+fn mint_parts_responder(
+    storage_base: String,
+) -> impl Fn(&Request) -> ResponseTemplate + Send + Sync + 'static {
+    move |req: &Request| {
+        let body: serde_json::Value =
+            serde_json::from_slice(&req.body).expect("mint request body must be JSON");
+        let nums = body
+            .get("part_numbers")
+            .and_then(|v| v.as_array())
+            .expect("mint request must carry a part_numbers array");
+        let parts: Vec<serde_json::Value> = nums
+            .iter()
+            .map(|n| {
+                let n = n.as_i64().expect("part_number must be an integer");
+                serde_json::json!({
+                    "part_number": n,
+                    "url": format!("{storage_base}/storage/spart/{n}"),
+                })
+            })
+            .collect();
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({ "parts": parts }))
+    }
+}
+
+/// A large file (> the 8 MiB single-PUT threshold) must use the STREAMING path:
+/// open the session WITHOUT `declared_size_bytes`, mint part URLs on demand via
+/// `POST /v1/uploads/{id}/parts` (carrying the finalize token in the header), and
+/// finalize the ascending `{part_number, e_tag}` list. This is the structural fix
+/// for URL expiry — no part URL is minted until just before its chunk is sent.
+#[tokio::test]
+async fn large_file_uses_streaming_jit_minting() {
+    let server = MockServer::start().await;
+    let storage_base = server.uri();
+    // 9 MiB over a 5 MiB part size -> 2 parts: 5 MiB + 4 MiB.
+    let part_size = 5 * MIB;
+    let contents: Vec<u8> = (0..9 * MIB).map(|i| (i % 251) as u8).collect();
+
+    // Create: streaming session — NO part_urls up front, part_size echoed.
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "finalize_token": "ftok_stream",
+            "headers": {},
+            "mode": "multipart",
+            "part_size": part_size,
+            "upload_id": "upl_stream",
+        })))
+        .mount(&server)
+        .await;
+
+    // On-demand mint endpoint.
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads/upl_stream/parts"))
+        .respond_with(mint_parts_responder(storage_base.clone()))
+        .mount(&server)
+        .await;
+
+    // Storage PUT targets, one per part, each returning a distinct ETag.
+    for n in 1..=2 {
+        Mock::given(method("PUT"))
+            .and(path(format!("/storage/spart/{n}")))
+            .respond_with(ResponseTemplate::new(200).insert_header("ETag", format!("\"etag-{n}\"")))
+            .mount(&server)
+            .await;
+    }
+
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads/upl_stream/finalize"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(mock_finalize_ok("upl_stream", contents.len())),
+        )
+        .mount(&server)
+        .await;
+
+    let path = temp_file(&contents);
+    let client = test_client(&server.uri());
+    let result = client.upload_file(&path, UploadOptions::default()).await;
+    let _ = std::fs::remove_file(&path);
+    let result = result.expect("streaming upload should succeed");
+    assert_eq!(result.upload_id, "upl_stream");
+
+    let requests = server.received_requests().await.expect("requests recorded");
+
+    // 1. The create request omitted declared_size_bytes (the streaming signal)
+    //    while still sending the part_size hint.
+    let create = requests
+        .iter()
+        .find(|r| r.url.path() == "/v1/uploads")
+        .expect("a create-session request should have been made");
+    let create_body: serde_json::Value =
+        serde_json::from_slice(&create.body).expect("create body JSON");
+    assert!(
+        create_body.get("declared_size_bytes").is_none(),
+        "streaming create must omit declared_size_bytes, body: {create_body}"
+    );
+    assert!(
+        create_body.get("part_size").is_some(),
+        "streaming create must still send the part_size hint, body: {create_body}"
+    );
+
+    // 2. The SDK minted part URLs on demand, carrying the finalize token in the
+    //    header, and asked for the 1-based part numbers it was about to upload.
+    let mints: Vec<&Request> = requests
+        .iter()
+        .filter(|r| r.url.path() == "/v1/uploads/upl_stream/parts")
+        .collect();
+    assert!(
+        !mints.is_empty(),
+        "the SDK must mint part URLs via POST /v1/uploads/{{id}}/parts"
+    );
+    let mut minted_numbers: Vec<i64> = Vec::new();
+    for mint in &mints {
+        assert_eq!(
+            mint.headers
+                .get("x-upload-finalize-token")
+                .and_then(|v| v.to_str().ok()),
+            Some("ftok_stream"),
+            "each mint must carry the finalize token in X-Upload-Finalize-Token"
+        );
+        let body: serde_json::Value = serde_json::from_slice(&mint.body).expect("mint body JSON");
+        let nums = body
+            .get("part_numbers")
+            .and_then(|v| v.as_array())
+            .expect("mint must send part_numbers");
+        assert!(!nums.is_empty(), "mint part_numbers must be non-empty");
+        for n in nums {
+            minted_numbers.push(n.as_i64().expect("part number int"));
+        }
+    }
+    minted_numbers.sort_unstable();
+    assert_eq!(
+        minted_numbers,
+        vec![1, 2],
+        "exactly parts 1 and 2 must be minted (each once)"
+    );
+
+    // 3. Each part received its slice ([0..5MiB), [5MiB..9MiB)).
+    let expected = [&contents[0..5 * MIB], &contents[5 * MIB..9 * MIB]];
+    for (i, slice) in expected.iter().enumerate() {
+        let part_path = format!("/storage/spart/{}", i + 1);
+        let put = requests
+            .iter()
+            .find(|r| r.url.path() == part_path)
+            .unwrap_or_else(|| panic!("a PUT to {part_path} should have been made"));
+        assert_eq!(&put.body[..], *slice, "part {} body slice", i + 1);
+        assert_no_sdk_headers(put);
+    }
+
+    // 4. Finalize carried the ascending {part_number, e_tag} list.
+    let finalize = requests
+        .iter()
+        .find(|r| r.url.path() == "/v1/uploads/upl_stream/finalize")
+        .expect("a finalize request should have been made");
+    let body: serde_json::Value = serde_json::from_slice(&finalize.body).expect("finalize JSON");
+    let parts = body
+        .get("parts")
+        .and_then(|p| p.as_array())
+        .expect("finalize must send a parts array");
+    assert_eq!(parts.len(), 2, "both parts must be finalized");
+    for (i, part) in parts.iter().enumerate() {
+        assert_eq!(
+            part.get("part_number").and_then(|v| v.as_i64()),
+            Some((i + 1) as i64),
+            "parts ascending and 1-based"
+        );
+        assert_eq!(
+            part.get("e_tag").and_then(|v| v.as_str()),
+            Some(format!("\"etag-{}\"", i + 1).as_str()),
+            "ETag forwarded byte-for-byte"
+        );
+    }
+}
+
+/// An expired part URL (storage 403 / SignatureDoesNotMatch) on the streaming
+/// path must NOT abort the upload: the SDK re-mints that single part via
+/// `POST /v1/uploads/{id}/parts` and retries the `PUT`, so a slow upload whose
+/// pre-minted URL lapsed still completes. (Today a storage 403 aborts the whole
+/// upload — see `storage_error_status_is_surfaced`.)
+#[tokio::test]
+async fn expired_part_url_is_reminted_and_retried() {
+    let server = MockServer::start().await;
+    let storage_base = server.uri();
+    let part_size = 5 * MIB;
+    let contents: Vec<u8> = (0..9 * MIB).map(|i| (i % 251) as u8).collect();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "finalize_token": "ftok_exp",
+            "headers": {},
+            "mode": "multipart",
+            "part_size": part_size,
+            "upload_id": "upl_exp",
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads/upl_exp/parts"))
+        .respond_with(mint_parts_responder(storage_base.clone()))
+        .mount(&server)
+        .await;
+
+    // Part 1's URL is "expired": first PUT gets 403 (S3-style), then 200 after a
+    // re-mint. Part 2 succeeds outright.
+    Mock::given(method("PUT"))
+        .and(path("/storage/spart/1"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .set_body_string("<Error><Code>SignatureDoesNotMatch</Code></Error>"),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/storage/spart/1"))
+        .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"etag-1\""))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/storage/spart/2"))
+        .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"etag-2\""))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/uploads/upl_exp/finalize"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(mock_finalize_ok("upl_exp", contents.len())),
+        )
+        .mount(&server)
+        .await;
+
+    let path = temp_file(&contents);
+    // Serial uploads so the 403/re-mint sequence on part 1 is deterministic.
+    let opts = UploadOptions {
+        max_concurrency: Some(1),
+        ..UploadOptions::default()
+    };
+    let client = test_client(&server.uri());
+    let result = client.upload_file(&path, opts).await;
+    let _ = std::fs::remove_file(&path);
+    result.expect("upload must complete after re-minting the expired part");
+
+    let requests = server.received_requests().await.expect("requests recorded");
+
+    // Part 1 was PUT twice: the expired 403 then the retry after re-mint.
+    let p1_puts = requests
+        .iter()
+        .filter(|r| r.url.path() == "/storage/spart/1")
+        .count();
+    assert_eq!(p1_puts, 2, "part 1 must be retried after the 403");
+
+    // Part 1 (number 1) was minted at least twice: the initial batch and the
+    // single-part re-mint.
+    let p1_mints = requests
+        .iter()
+        .filter(|r| r.url.path() == "/v1/uploads/upl_exp/parts")
+        .filter(|r| {
+            serde_json::from_slice::<serde_json::Value>(&r.body)
+                .ok()
+                .and_then(|b| {
+                    b.get("part_numbers")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.iter().any(|n| n.as_i64() == Some(1)))
+                })
+                .unwrap_or(false)
+        })
+        .count();
+    assert!(
+        p1_mints >= 2,
+        "part 1 must be re-minted after its URL expired, saw {p1_mints} mints for it"
+    );
+}


### PR DESCRIPTION
Fixes #76. Large uploads (>8 MiB) now open a streaming session (omitting `declared_size_bytes`) and mint part URLs on demand via `POST /v1/uploads/{id}/parts` just before each chunk, re-minting a single part on a 403/expired-URL, so a slow upload can no longer outlive a presigned URL's ~30-minute TTL. Small files keep the known-size single-PUT path unchanged.