### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-29
+
+### Added
+
+- Streaming uploads with just-in-time part minting for large files.
+  `Client::upload_file` now opens a streaming multipart session for files past
+  the multipart threshold and mints presigned part URLs on demand (via
+  `POST /v1/uploads/{id}/parts`) immediately before each chunk uploads, instead
+  of pre-minting every URL when the session opens. A part URL that expires
+  mid-transfer (storage `403`) is transparently re-minted and the chunk retried,
+  so large or slow uploads that outlive a presigned URL's ~30-minute TTL still
+  complete within the session's 24-hour window rather than failing partway.
+  Small files keep the single-`PUT` fast path. (Fixes #76.)
+- Low-level `POST /v1/uploads/{id}/parts` part-minting endpoint with its
+  `MintUploadPartsRequest` / `MintUploadPartsResponse` / `MintedUploadPartResponse`
+  models, generated from the OpenAPI spec.
+
 ### Changed
 
 - Token exchange (`POST /v1/auth/jwt`) now retries transient failures before
@@ -16,7 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (bad/expired credential) is never retried, and the last status/body is
   preserved once the budget is exhausted. Applies to both the initial mint and
   the refresh path.
-- feat(uploads): support streaming uploads with on-demand part URLs
+
+### Fixed
+
+- The default `User-Agent` is now computed from the crate version at build time
+  (`CARGO_PKG_VERSION`) instead of a hardcoded string, so it always reflects the
+  published version.
 
 ## [0.5.0] - 2026-06-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"


### PR DESCRIPTION
Release v0.6.0. Headline: streaming uploads with just-in-time part minting for large files (fixes #76), verified end-to-end with a 15 GB upload. Also bundles the token-exchange transient-retry change and the version-derived default User-Agent fix.

Tag `v0.6.0` after merge to publish to crates.io and cut the GitHub release.