### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-30
+
 ### Added
 
 - Multipart uploads now survive transient per-part failures. A single part

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"


### PR DESCRIPTION
Release v0.7.0. Resilient multipart upload retries (outer round-loop re-sweep of failed parts + per-part PUT timeout) and per-part just-in-time URL minting. Removes the `MAX_MINT_BATCH` public const (obsoleted by per-part minting).
