### PR TITLE
chore: release hotdata v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.8.0] - 2026-07-07
+
 ### Changed
 
 - feat: support async table loads and append mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"


### PR DESCRIPTION
Release **hotdata v0.8.0**: version bumped in `Cargo.toml` and `CHANGELOG.md` updated. After merge, run `./scripts/release.sh publish` from a clean `main` checkout.