### PR TITLE
chore: release hotdata v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-15
+
 ### Changed
 
 - feat(databases): add fork endpoint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"


### PR DESCRIPTION
Release `hotdata` v0.9.0.

Rolls the accumulated `[Unreleased]` entries into `## [0.9.0]`:

- feat(databases): add fork endpoint — new typed `fork_database` method + `ForkDatabaseRequest` model
- chore(api): exclude datasets from public OpenAPI spec + docs cleanup

Minor bump (0.8.1 → 0.9.0): additive new endpoint, no breaking changes to existing surface. On merge, push tag `v0.9.0` to trigger crates.io publish + GitHub release.