### PR TITLE
feat(databases): add ergonomic fork() wrapper + release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-15
+
+### Added
+
+- Ergonomic `Client::databases().fork()` wrapper for the `fork_database` endpoint.
+
 ## [0.9.0] - 2026-07-15
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -237,6 +237,15 @@ impl<'a> DatabasesApi<'a> {
         apis::databases_api::create_database(self.config, request).await
     }
 
+    /// Fork a database into a new, independent database.
+    pub async fn fork(
+        &self,
+        database_id: &str,
+        request: models::ForkDatabaseRequest,
+    ) -> Result<models::CreateDatabaseResponse, Error<apis::databases_api::ForkDatabaseError>> {
+        apis::databases_api::fork_database(self.config, database_id, request).await
+    }
+
     /// Fetch a database by id.
     pub async fn get(
         &self,


### PR DESCRIPTION
Adds the hand-written ergonomic wrapper `Client::databases().fork(database_id, ForkDatabaseRequest)` for the `fork_database` endpoint that shipped in v0.9.0.

The v0.9.0 regen added the generated `apis::databases_api::fork_database` free function, but the regen-immune ergonomic layer (`src/resources.rs`) had no matching handle method, so `client.databases().fork()` didn't exist — inconsistent with `create`/`get`/`list`/`delete`. This restores parity so downstream consumers (the CLI) can call fork through the same resource-oriented surface as every other database op.

Also bumps to v0.9.1 and rolls the changelog. On merge, push tag `v0.9.1` to publish.