### PR TITLE
chore: release hotdata v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-23
+
 ### Changed
 
-- chore(databases): make pagination fields nullable
+- **Breaking:** `list_databases` and `Databases::list` now take `limit` and
+  `cursor` pagination parameters; existing callers must pass `None, None`.
+- Pagination metadata on `ListDatabasesResponse` (`count`, `limit`, `has_more`)
+  is now nullable so the client tolerates responses from a server that predates
+  these fields (rolling deploy / version skew).
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["developers@hotdata.dev"]
 description = "Powerful data platform API for datasets, queries, and analytics."
 license = "MIT"


### PR DESCRIPTION
Release v0.10.0. Rolls up the [Unreleased] changes:

- **Breaking:** `list_databases` / `Databases::list` now take `limit`/`cursor` pagination params (existing callers pass `None, None`).
- `ListDatabasesResponse` pagination metadata (`count`/`limit`/`has_more`) is nullable → tolerant of servers predating those fields.
- (already staged) `/v1/files` removal; `LoadManagedTableRequest.key`.

Bumps Cargo.toml 0.9.1 → 0.10.0 and moves the changelog. Tagging `v0.10.0` after merge triggers publish. Unblocks the hotdata-cli databases-list pagination work.